### PR TITLE
Update getQueryByUUID

### DIFF
--- a/PicSureHpdsLib/PicSureHpds.py
+++ b/PicSureHpdsLib/PicSureHpds.py
@@ -92,7 +92,7 @@ class HpdsResourceConnection:
         return PicSureHpdsLib.Dictionary(self)
 
     def getQueryByUUID(self, query_uuid):
-        metadataStr = self.connection_reference._api_obj().queryMetadata(query_uuid, self.resource_uuid)
+        metadataStr = self.connection_reference._api_obj().queryMetadata(query_uuid)
         metadata = json.loads(metadataStr)
         query = PicSureHpdsLib.Query(self)
         query.load(metadata["resultMetadata"]["queryJson"])

--- a/PicSureHpdsLib/PicSureHpds.py
+++ b/PicSureHpdsLib/PicSureHpds.py
@@ -92,14 +92,11 @@ class HpdsResourceConnection:
         return PicSureHpdsLib.Dictionary(self)
 
     def getQueryByUUID(self, query_uuid):
-        metadataStr = self.connection_reference._api_obj().queryMetadata(query_uuid)
-        print("STR ", metadataStr)
-        metadata = json.loads( metadataStr )
-        print("JSON ", metadata)
+        metadataStr = self.connection_reference._api_obj().queryMetadata(query_uuid, self.resource_uuid)
+        metadata = json.loads(metadataStr)
         query = PicSureHpdsLib.Query(self)
-        # use 'load' here instead of passing in as a param to avoid parsing to a string and back
         query.load(metadata["resultMetadata"]["queryJson"])
-        return query;
+        return query
 
     def query(self, load_query=None):
         # retrieve PSAMA profile info if not previously done


### PR DESCRIPTION
We now pass the resource_uuid to the queryMetadata method. Removed print statements as it causes unnecessary clutter.