### PR TITLE
Fix nine correctness bugs surfaced by code review

### DIFF
--- a/src/picsure/_dev/redaction.py
+++ b/src/picsure/_dev/redaction.py
@@ -50,7 +50,10 @@ def redact_for_log(
     if _is_psama_path(path):
         return json.dumps(_redact_psama_secrets(body))
 
-    if _is_query_sync_path(path) and _body_is_participant_like(body):
+    # Suppress based on body SHAPE, not path: the async PFB export posts the
+    # same participant-bearing query body to /picsure/v3/query (and
+    # /status, /result), none of which end in /query/sync.
+    if _body_is_participant_like(body):
         return None
 
     # Default: safe to log
@@ -69,16 +72,11 @@ def body_is_sensitive(
     """
     if body is None:
         return False
-    return _is_query_sync_path(path) and _body_is_participant_like(body)
+    return _body_is_participant_like(body)
 
 
 def _is_psama_path(path: str) -> bool:
     return path.startswith("/psama/")
-
-
-def _is_query_sync_path(path: str) -> bool:
-    # Matches both /picsure/query/sync and /picsure/v3/query/sync.
-    return path.endswith("/query/sync")
 
 
 def _body_is_participant_like(body: Any) -> bool:

--- a/src/picsure/_models/facet.py
+++ b/src/picsure/_models/facet.py
@@ -7,6 +7,17 @@ from typing import cast
 from picsure.errors import PicSureValidationError
 
 
+def _coerce_count(raw: object) -> int:
+    if isinstance(raw, bool):
+        return 0
+    if isinstance(raw, int):
+        return raw
+    try:
+        return int(float(raw))  # type: ignore[arg-type]  # handles "5.0", 5.0, "1234"
+    except (TypeError, ValueError):
+        return 0
+
+
 @dataclass(frozen=True)
 class Facet:
     """A single facet option with its count.
@@ -55,10 +66,12 @@ class Facet:
             child_indices = children_of.get(idx, [])
             own_children = [cast(Facet, facets[i]) for i in child_indices]
             raw_count = node.get("count", 0)
-            raw_value = node.get("name", node.get("value"))
+            raw_value = node.get("name")
+            if raw_value is None:
+                raw_value = node.get("value")
             facets[idx] = cls(
                 value=str(raw_value) if raw_value is not None else "",
-                count=int(cast(int, raw_count)),
+                count=_coerce_count(raw_count),
                 display=str(node.get("display") or ""),
                 description=str(node.get("description") or ""),
                 children=own_children,

--- a/src/picsure/_models/session.py
+++ b/src/picsure/_models/session.py
@@ -504,4 +504,12 @@ class Session:
                 "No resources are available on this connection. "
                 "Check with your administrator."
             )
-        return self._resources[0].uuid
+        if len(self._resources) == 1:
+            return self._resources[0].uuid
+        listing = "\n".join(f"  {r.uuid}  {r.name}" for r in self._resources)
+        raise PicSureValidationError(
+            "This connection has multiple resources and none has been "
+            "selected. Call session.setResourceID(uuid) to choose one "
+            "before searching or querying.\n\n"
+            f"Available resources:\n{listing}"
+        )

--- a/src/picsure/_services/connect.py
+++ b/src/picsure/_services/connect.py
@@ -291,4 +291,11 @@ def _fetch_resources(
             for uuid, name in data.items()
         ]
 
-    return [Resource.from_dict(r) for r in data]
+    if not isinstance(data, list):
+        raise PicSureConnectionError(
+            f"Connected to {display_name} but received an unexpected "
+            "resources response from the server. The server may be "
+            "misconfigured or temporarily unavailable."
+        )
+
+    return [Resource.from_dict(r) for r in data if isinstance(r, dict)]

--- a/src/picsure/_services/connect.py
+++ b/src/picsure/_services/connect.py
@@ -87,11 +87,17 @@ def connect(
     Example:
         >>> import picsure
         >>> session = picsure.connect(
-        ...     platform="BDC Authorized",
+        ...     platform=picsure.Platform.BDC_AUTHORIZED,
         ...     token="your-api-token",
         ... )
         You're successfully connected to BDC Authorized as user you@email.com!
         Your token expires on 2026-06-15T00:00:00Z.
+
+        >>> # Custom deployment: pass a full URL string
+        >>> session = picsure.connect(
+        ...     platform="https://my-picsure.example.com",
+        ...     token="your-api-token",
+        ... )
 
         >>> # Open-access: no token needed
         >>> session = picsure.connect(platform=picsure.Platform.BDC_OPEN)

--- a/src/picsure/_services/export.py
+++ b/src/picsure/_services/export.py
@@ -24,11 +24,12 @@ _STATUS_PATH_TEMPLATE = "/picsure/v3/query/{query_id}/status"
 _RESULT_PATH_TEMPLATE = "/picsure/v3/query/{query_id}/result"
 
 # Terminal status values returned by PIC-SURE's ``PicSureStatus`` enum.
-# AVAILABLE is the success terminal; ERROR is the failure terminal.
-# QUEUED / PENDING are in-progress; HPDS also uses RUNNING in some paths.
+# Only AVAILABLE (success) and ERROR (failure) are terminal; every other
+# status (QUEUED, PENDING, RUNNING, STARTED, PROCESSING, or any future HPDS
+# value surfaced via ``resourceStatus``) is treated as in-progress and we
+# keep polling, bounded by ``_TOTAL_TIMEOUT_SECONDS`` (10 minutes).
 _STATUS_AVAILABLE = "AVAILABLE"
 _STATUS_ERROR = "ERROR"
-_IN_PROGRESS_STATUSES = frozenset({"QUEUED", "PENDING", "RUNNING"})
 
 # Polling parameters.  The sequence is 1s, 2s, 4s, 8s, 16s, 32s, 60s, 60s, ...
 # (doubling, capped at 60s per poll).  Cumulative elapsed time is bounded
@@ -147,12 +148,8 @@ def _poll_until_available(
             raise PicSureQueryError(
                 f"PFB export failed on the server (query {query_id} status=ERROR)."
             )
-        if status not in _IN_PROGRESS_STATUSES:
-            # Unknown status — treat as failure rather than spin forever.
-            raise PicSureQueryError(
-                f"PFB export returned an unexpected status '{status}' for "
-                f"query {query_id}."
-            )
+        # Any other status is treated as in-progress; keep polling. The
+        # 10-minute total timeout below protects against an infinite loop.
 
         elapsed = time.monotonic() - start
         if elapsed >= _TOTAL_TIMEOUT_SECONDS:

--- a/src/picsure/_services/query_build.py
+++ b/src/picsure/_services/query_build.py
@@ -129,7 +129,7 @@ def buildClauseGroup(  # noqa: N802
     if not clauses:
         raise PicSureValidationError("A clause group must contain at least one clause.")
 
-    return ClauseGroup(clauses=clauses, operator=operator)
+    return ClauseGroup(clauses=list(clauses), operator=operator)
 
 
 def buildQuery(  # noqa: N802

--- a/src/picsure/_services/query_save.py
+++ b/src/picsure/_services/query_save.py
@@ -22,7 +22,7 @@ _NAMED_DATASET_COLLECTION_PATH = "/picsure/dataset/named"
 _NAMED_DATASET_ITEM_PATH = "/picsure/dataset/named/{named_dataset_id}"
 
 # Mirrors the @Pattern on NamedDatasetRequest.name in pic-sure-api-data.
-_NAME_PATTERN = re.compile(r"^[\w\d \-\\/?+=\[\]\.():\"']+$")
+_NAME_PATTERN = re.compile(r"\A[\w\d \-\\/?+=\[\]\.():\"']+\Z")
 _NAME_MAX_LEN = 255
 
 
@@ -69,13 +69,19 @@ def save_query_by_name(
     if existing is None:
         _create_named_dataset(client, query_id=query_id, name=name)
     else:
+        existing_uuid = existing.get("uuid")
+        if not existing_uuid:
+            raise PicSureQueryError(
+                f"The named query matching '{name}' is missing its identifier; "
+                "cannot overwrite it."
+            )
         metadata_raw = existing.get("metadata")
         metadata: dict[str, object] = (
             metadata_raw if isinstance(metadata_raw, dict) else {}
         )
         _update_named_dataset(
             client,
-            named_dataset_id=str(existing["uuid"]),
+            named_dataset_id=str(existing_uuid),
             query_id=query_id,
             name=name,
             archived=bool(existing.get("archived", False)),

--- a/src/picsure/_services/search.py
+++ b/src/picsure/_services/search.py
@@ -156,16 +156,19 @@ def searchDictionary(  # noqa: N802
         ) from exc
 
     content = data.get("content", [])
-    total_elements = data.get("totalElements", len(content) if content else 0)
+    total_elements = data.get("totalElements")  # may be None
     last = data.get("last")
     # The "one big page" strategy assumes the single request returned every
-    # match. If the server paginated (``last`` missing or False) or the
-    # counts disagree, surface loudly — a stale ``total_concepts`` from
-    # connect-time or a server-side page-size cap would otherwise silently
-    # truncate results.
-    if last is not True or len(content) != total_elements:
+    # match. Only treat as truncated when there is positive evidence of more
+    # pages: an explicit ``last: false`` or a present-but-mismatched
+    # ``totalElements``. Missing fields must not trigger a false failure.
+    truncated = last is False or (
+        total_elements is not None and len(content) != total_elements
+    )
+    if truncated:
+        total_repr = total_elements if total_elements is not None else "unknown"
         raise PicSureQueryError(
-            f"Search returned a truncated page ({len(content)}/{total_elements} "
+            f"Search returned a truncated page ({len(content)}/{total_repr} "
             "entries). Reconnect to refresh the concept count."
         )
 

--- a/src/picsure/_transport/platforms.py
+++ b/src/picsure/_transport/platforms.py
@@ -169,10 +169,9 @@ def resolve_platform(
             requires_auth=True if requires_auth is None else requires_auth,
         )
 
-    valid = ", ".join(p.label for p in Platform)
+    valid = ", ".join(f"Platform.{p.name}" for p in Platform)
     raise PicSureValidationError(
-        f"'{platform}' is not a recognized platform. "
-        f"Valid platforms: {valid}. "
-        "You can also pass a Platform enum member or a full URL "
-        "(e.g. 'https://my-picsure.example.com')."
+        f"{platform!r} is not a recognized platform. "
+        f"Pass a Platform enum member (one of: {valid}) or a full URL "
+        "string (e.g. 'https://my-picsure.example.com')."
     )

--- a/tests/unit/dev/test_redaction.py
+++ b/tests/unit/dev/test_redaction.py
@@ -88,6 +88,28 @@ def test_redact_pfb_export_returns_none():
     assert out is None
 
 
+def test_redact_async_pfb_query_returns_none():
+    # The async PFB export posts the same participant-bearing body to
+    # /picsure/v3/query (no /query/sync suffix). Must still be suppressed.
+    body = {"query": {"expectedResultType": "DATAFRAME_PFB", "fields": []}}
+    out = redact_for_log("/picsure/v3/query", "POST", body)
+    assert out is None
+
+
+def test_redact_async_pfb_result_returns_none():
+    body = {"query": {"expectedResultType": "DATAFRAME_PFB", "fields": []}}
+    out = redact_for_log("/picsure/v3/query/abc-123/result", "POST", body)
+    assert out is None
+
+
+def test_redact_async_count_query_is_preserved():
+    # COUNT bodies are not participant-like and remain loggable on async paths.
+    body = {"query": {"expectedResultType": "COUNT", "fields": []}}
+    out = redact_for_log("/picsure/v3/query", "POST", body)
+    assert out is not None
+    assert "COUNT" in out
+
+
 def test_redact_info_resources_is_preserved():
     body = {"uuid-1": "hpds"}
     out = redact_for_log("/picsure/info/resources", "GET", body)

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -168,6 +168,32 @@ class TestConnectConnectionErrors:
         assert "resources" in msg.lower()
 
     @respx.mock
+    def test_null_resources_payload_raises_connection_error(self, profile_response):
+        respx.get(f"{BASE_URL}/psama/user/me").mock(
+            return_value=httpx.Response(200, json=profile_response)
+        )
+        respx.get(f"{BASE_URL}/picsure/info/resources").mock(
+            return_value=httpx.Response(
+                200, content=b"null", headers={"content-type": "application/json"}
+            )
+        )
+
+        with pytest.raises(PicSureConnectionError, match="unexpected resources"):
+            connect(platform=BASE_URL, token=TOKEN)
+
+    @respx.mock
+    def test_string_resources_payload_raises_connection_error(self, profile_response):
+        respx.get(f"{BASE_URL}/psama/user/me").mock(
+            return_value=httpx.Response(200, json=profile_response)
+        )
+        respx.get(f"{BASE_URL}/picsure/info/resources").mock(
+            return_value=httpx.Response(200, json="not-a-list")
+        )
+
+        with pytest.raises(PicSureConnectionError, match="unexpected resources"):
+            connect(platform=BASE_URL, token=TOKEN)
+
+    @respx.mock
     def test_concepts_prefetch_failure_raises_connection_error(
         self, profile_response, resources_response
     ):

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -66,6 +66,26 @@ class TestExportPFBHappyPath:
         sleep_mock.assert_called_once_with(1.0)
 
     @respx.mock
+    def test_unknown_in_progress_status_keeps_polling(self, tmp_path):
+        # "STARTED" is a legitimate in-flight HPDS status that is not in the
+        # old hardcoded set; it must not abort the export.
+        respx.post(SUBMIT_URL).mock(return_value=_submit_ok())
+        respx.post(STATUS_URL).mock(
+            side_effect=[_status("STARTED"), _status("AVAILABLE")]
+        )
+        respx.post(RESULT_URL).mock(
+            return_value=httpx.Response(200, content=b"pfb_content")
+        )
+
+        output = tmp_path / "out.pfb"
+        with patch("picsure._services.export.time.sleep") as sleep_mock:
+            export_pfb(_make_client(), RESOURCE_UUID, _simple_clause(), output)
+
+        assert output.exists()
+        assert output.read_bytes() == b"pfb_content"
+        sleep_mock.assert_called_once_with(1.0)
+
+    @respx.mock
     def test_sends_pfb_result_type_and_resource_uuid(self, tmp_path):
         import json
 
@@ -152,6 +172,23 @@ class TestExportPFBBackoff:
         # After the 6th interval (32s), subsequent values must all be 60s.
         assert intervals[:6] == [1.0, 2.0, 4.0, 8.0, 16.0, 32.0]
         assert all(v == 60.0 for v in intervals[6:])
+
+
+class TestExportPFBErrorStatus:
+    @respx.mock
+    def test_error_status_raises_query_error(self, tmp_path):
+        respx.post(SUBMIT_URL).mock(return_value=_submit_ok())
+        respx.post(STATUS_URL).mock(side_effect=[_status("STARTED"), _status("ERROR")])
+
+        output = tmp_path / "out.pfb"
+        with (
+            patch("picsure._services.export.time.sleep"),
+            pytest.raises(PicSureQueryError, match="status=ERROR"),
+        ):
+            export_pfb(_make_client(), RESOURCE_UUID, _simple_clause(), output)
+
+        assert not output.exists()
+        assert not (tmp_path / "out.pfb.part").exists()
 
 
 class TestExportPFBTimeout:

--- a/tests/unit/test_facets.py
+++ b/tests/unit/test_facets.py
@@ -25,6 +25,22 @@ class TestFacet:
         assert facet.count == 42
         assert facet.display == ""
 
+    def test_from_dict_null_count(self):
+        data = {"name": "phs000007", "count": None}
+        facet = Facet.from_dict(data)
+        assert facet.count == 0
+        assert facet.value == "phs000007"
+
+    def test_from_dict_string_float_count(self):
+        data = {"name": "phs000007", "count": "5.0"}
+        facet = Facet.from_dict(data)
+        assert facet.count == 5
+
+    def test_from_dict_null_name_uses_value(self):
+        data = {"name": None, "value": "phs000007", "count": 3}
+        facet = Facet.from_dict(data)
+        assert facet.value == "phs000007"
+
     def test_frozen(self):
         facet = Facet(value="test", count=10)
         with pytest.raises(AttributeError):

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -113,9 +113,17 @@ class TestResolvePlatform:
         with pytest.raises(PicSureValidationError, match="not a recognized platform"):
             resolve_platform("NonExistentPlatform")
 
-    def test_unknown_string_lists_valid_options(self):
-        with pytest.raises(PicSureValidationError, match="BDC Authorized"):
+    def test_unknown_string_lists_enum_member_forms(self):
+        with pytest.raises(PicSureValidationError, match=r"Platform\.BDC_AUTHORIZED"):
             resolve_platform("typo")
+
+    def test_unknown_string_does_not_list_labels_as_valid_input(self):
+        with pytest.raises(PicSureValidationError) as exc_info:
+            resolve_platform("typo")
+        msg = str(exc_info.value)
+        assert "full URL" in msg
+        # Human labels must not be presented as valid input forms.
+        assert "Valid platforms:" not in msg
 
     def test_nhanes_open_resolves(self):
         info = resolve_platform(Platform.NHANES_OPEN)

--- a/tests/unit/test_query_build.py
+++ b/tests/unit/test_query_build.py
@@ -219,6 +219,16 @@ class TestBuildClauseGroup:
         with pytest.raises(PicSureValidationError, match="at least one"):
             buildClauseGroup([])
 
+    def test_copies_caller_list(self):
+        c1 = buildClause("\\p1\\", type=PhenotypicFilterType.FILTER, categories="A")
+        c2 = buildClause("\\p2\\", type=PhenotypicFilterType.FILTER, categories="B")
+        clauses = [c1, c2]
+        group = buildClauseGroup(clauses, operator=GroupOperator.AND)
+        clauses.append(
+            buildClause("\\p3\\", type=PhenotypicFilterType.FILTER, categories="C")
+        )
+        assert len(group.clauses) == 2
+
     def test_serializes_end_to_end(self):
         sex = buildClause(
             "\\sex\\", type=PhenotypicFilterType.FILTER, categories="Male"

--- a/tests/unit/test_query_save.py
+++ b/tests/unit/test_query_save.py
@@ -202,6 +202,37 @@ class TestSaveQueryByNameDuplicates:
         }
 
     @respx.mock
+    def test_overwrite_matched_record_without_uuid_raises_query_error(self):
+        # A matched record lacking a uuid must raise a clean PicSureQueryError
+        # instead of crashing with KeyError on existing["uuid"].
+        respx.get(LIST_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "name": "fun",
+                        "queryId": "qid-old",
+                        "archived": False,
+                        "metadata": {},
+                    }
+                ],
+            )
+        )
+        respx.post(SUBMIT_URL).mock(
+            return_value=httpx.Response(200, json={"picsureResultId": "qid-new"})
+        )
+
+        with pytest.raises(PicSureQueryError, match="missing its identifier"):
+            save_query_by_name(
+                _client(),
+                RESOURCE_UUID,
+                _clause(),
+                "fun",
+                use_legacy_query_path=False,
+                overwrite=True,
+            )
+
+    @respx.mock
     def test_overwrite_true_creates_when_no_existing_record(self):
         # overwrite=True should still create-via-POST if there is no match.
         respx.get(LIST_URL).mock(return_value=httpx.Response(200, json=[]))
@@ -246,6 +277,23 @@ class TestSaveQueryByNameNameValidation:
         ],
     )
     def test_rejects_bad_characters(self, bad_name):
+        with pytest.raises(PicSureValidationError, match="unsupported characters"):
+            save_query_by_name(
+                _client(),
+                RESOURCE_UUID,
+                _clause(),
+                bad_name,
+                use_legacy_query_path=False,
+            )
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "My Query\n",
+            "trailing newline\n",
+        ],
+    )
+    def test_rejects_trailing_newline(self, bad_name):
         with pytest.raises(PicSureValidationError, match="unsupported characters"):
             save_query_by_name(
                 _client(),

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -293,7 +293,7 @@ class TestSearch:
     @respx.mock
     def test_last_missing_but_counts_match_ok(self):
         # If last is missing but totalElements matches content length,
-        # treat as truncated (strict policy).
+        # there is no positive evidence of more pages -> complete.
         response = {
             "content": [{"conceptPath": "\\x\\", "name": "x"}],
             "totalElements": 1,
@@ -301,8 +301,18 @@ class TestSearch:
         respx.post(_concepts_url(100)).mock(
             return_value=httpx.Response(200, json=response)
         )
-        with pytest.raises(PicSureQueryError, match="truncated"):
-            searchDictionary(_make_client(), term="x")
+        df = searchDictionary(_make_client(), term="x")
+        assert len(df) == 1
+
+    @respx.mock
+    def test_last_and_total_both_missing_ok(self):
+        # No last, no totalElements -> no evidence of truncation -> complete.
+        response = {"content": [{"conceptPath": "\\x\\", "name": "x"}]}
+        respx.post(_concepts_url(100)).mock(
+            return_value=httpx.Response(200, json=response)
+        )
+        df = searchDictionary(_make_client(), term="x")
+        assert len(df) == 1
 
     @respx.mock
     def test_total_elements_mismatch_raises_even_when_last_true(self):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -175,9 +175,27 @@ class TestSessionDefaultResourceUuid:
         )
         assert session._default_resource_uuid() == "uuid-2"
 
-    def test_returns_first_resource_when_not_set(self):
+    def test_returns_single_resource_when_not_set(self):
+        session = _make_session(
+            resources=[Resource(uuid="only-uuid", name="Solo", description="")]
+        )
+        assert session._default_resource_uuid() == "only-uuid"
+
+    def test_raises_when_multiple_resources_unselected(self):
+        import pytest
+
+        from picsure.errors import PicSureValidationError
+
         session = _make_session()
-        assert session._default_resource_uuid() == "uuid-1"
+        with pytest.raises(PicSureValidationError) as exc_info:
+            session._default_resource_uuid()
+        msg = str(exc_info.value)
+        assert "setResourceID" in msg
+        assert "Available resources:" in msg
+        assert "uuid-1" in msg
+        assert "Resource A" in msg
+        assert "uuid-2" in msg
+        assert "Resource B" in msg
 
     def test_raises_when_no_resources(self):
         session = _make_session(resources=[])


### PR DESCRIPTION
## Summary

Fixes nine correctness/robustness bugs found in a code review of the adapter. Each is a separate commit with its own tests, added TDD-style. Full suite: **600 passed, 17 skipped** (integration tier); `ruff`, `ruff format`, and `mypy --strict` all clean.

No public API changes (no new/renamed kwargs or enum members), so the R adapter's `reticulate` wrappers are unaffected.

## Fixes

| Commit | Problem | Fix |
|--------|---------|-----|
| `connect` resources guard | Non-list/dict `/info/resources` payload raised a raw `TypeError`, bypassing error translation | Reject non-list payloads with `PicSureConnectionError`; skip non-dict items |
| `platforms` docs/error | Documented `connect(platform="BDC Authorized")` raised; error listed labels that aren't valid input | Docstring uses `Platform.BDC_AUTHORIZED` + custom-URL form; error lists `Platform.<NAME>` members |
| `session` default resource | No UUID selected → silently queried `_resources[0]` | One resource → use it; multiple + none selected → raise with a resource listing |
| `redaction` by shape | Async PFB query bodies bypassed participant-body redaction (only `/query/sync` was covered) | Suppress by body shape (DATAFRAME/PFB/TIMESERIES) on any path |
| `search` truncation guard | Missing `last` caused false truncation errors; missing `totalElements` defeated the count check | Flag truncation only on explicit `last: false` or mismatched `totalElements` |
| `query_build` aliasing | `buildClauseGroup` stored the caller's list by reference in a frozen dataclass | Copy the list, matching `buildClause`/`buildQuery` |
| `facet` parsing | Null/non-integer `count` crashed the parse; null `name` dropped a present `value` | Tolerant count coercion; fall back to `value` only when `name` is `None` |
| `export` PFB poll | Any status outside `{QUEUED,PENDING,RUNNING}` aborted a healthy export | Only `AVAILABLE`/`ERROR` are terminal; unknown statuses keep polling (timeout-bounded) |
| `query_save` hardening | `^...$` regex let trailing newlines through; hard `existing["uuid"]` could `KeyError` | Anchor with `\A...\Z`; read `uuid` defensively and raise `PicSureQueryError` if absent |

## Behavior change to note

The `session` fix is the one intentional behavior change: a multi-resource connection with no `setResourceID()` now raises at query time instead of guessing. Single-resource and explicit-UUID workflows are unchanged.

## Test plan

- [x] `uv run pytest` — 600 passed, 17 skipped
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run mypy src/`
- [x] R adapter unit tests (`devtools::test()`) — 437 passed (wrappers mock the Python module; confirms no R-side contract drift)