### PR TITLE
ALS-11934: include filter-clause variables in query output

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -22,7 +22,8 @@ typical session flows:
    the output concepts to return via `picsure.buildQuery(...)`.
 3. **Run.** `session.runQuery(query, type=...)` calls the query-run
    service, which splits the `Query` (or bare `Clause` / `ClauseGroup`)
-   into a phenotypic filter tree and `includeConcepts`, serializes to v3
+   into a phenotypic filter tree and the output `select` — the filter's own
+   variables folded together with any `includeConcepts` — serializes to v3
    wire format, POSTs to `/picsure/v3/query/sync`, and parses the response
    into a `CountResult`, a `dict[str, CountResult]`, or a
    `DataFrame`.
@@ -89,7 +90,7 @@ src/picsure/
 | `resource.py`      | `Resource` dataclass (`uuid`, `name`, `description`) with a `from_dict` constructor for `/picsure/info/resources` payloads. |
 | `clause.py`        | `Clause` dataclass + `PhenotypicFilterType` enum (`FILTER`, `ANYRECORD`, `REQUIRE`). Each `Clause.to_query_json()` emits the v3 `PhenotypicClause` shape. |
 | `clause_group.py`  | `ClauseGroup` dataclass + `GroupOperator` enum (`AND`, `OR`). Recursively serializes to a v3 `PhenotypicSubquery`. |
-| `query.py`         | `Query` dataclass: a `phenotypicFilter` (`Clause | ClauseGroup | None`) plus `includeConcepts` (output concept paths). `runQuery` also accepts a bare `Clause` / `ClauseGroup` (filter, no extra output columns). |
+| `query.py`         | `Query` dataclass: a `phenotypicFilter` (`Clause | ClauseGroup | None`) plus `includeConcepts` (output concept paths). `runQuery` also accepts a bare `Clause` / `ClauseGroup` (filter; its variables are returned as output columns). `concept_paths()` on each collects the filter's variables to fold into `select`. |
 | `query_type.py`    | `QueryType` enum (`COUNT`, `PARTICIPANT`, `TIMESTAMP`, `CROSS_COUNT`). Public API also accepts equivalent lowercase strings. |
 | `count_result.py`  | `CountResult` dataclass — preserves `value`, `margin`, `cap`, `raw`. Encodes exact / noisy / suppressed shapes from open-access backends. `obfuscated` property is a convenience. |
 | `dictionary.py`    | `DictionaryEntry` dataclass — one row of `searchDictionary` output, mapped from the backend `Concept` payload. |

--- a/docs/guides/building-queries.md
+++ b/docs/guides/building-queries.md
@@ -135,6 +135,12 @@ count = session.runQuery(filters, type="count")
 
 `includeConcepts` preserves order and drops duplicates.
 
+Variables you filter on are returned automatically — you don't need to repeat
+them in `includeConcepts`. Use `includeConcepts` only for *additional* output
+columns that aren't already part of the filter. A bare `Clause`/`ClauseGroup`
+run as `participant` therefore returns its filtered variables as columns, not
+just the participant ID.
+
 ### Full Example from the Product Spec
 
 Select participants who are male, over 40, and have either

--- a/src/picsure/_models/clause.py
+++ b/src/picsure/_models/clause.py
@@ -57,6 +57,15 @@ class Clause:
     min: float | None = None
     max: float | None = None
 
+    def concept_paths(self) -> list[str]:
+        """Concept paths this clause references, in order.
+
+        Used to fold a query's filter variables into the output ``select``
+        array so they are returned without being repeated in
+        ``includeConcepts``.
+        """
+        return list(self.keys)
+
     def to_query_json(self) -> dict[str, object]:
         """Serialize this clause as a v3 ``PhenotypicClause``.
 

--- a/src/picsure/_models/clause_group.py
+++ b/src/picsure/_models/clause_group.py
@@ -34,6 +34,14 @@ class ClauseGroup:
     clauses: list[Clause | ClauseGroup]
     operator: GroupOperator
 
+    def concept_paths(self) -> list[str]:
+        """All concept paths referenced anywhere in this group, depth-first.
+
+        Recurses uniformly through nested groups because each child —
+        ``Clause`` or ``ClauseGroup`` — implements ``concept_paths()``.
+        """
+        return [path for child in self.clauses for path in child.concept_paths()]
+
     def to_query_json(self) -> dict[str, object]:
         """Serialize this group as a v3 ``PhenotypicSubquery``."""
         return {

--- a/src/picsure/_models/query.py
+++ b/src/picsure/_models/query.py
@@ -19,7 +19,7 @@ class Query:
 
     The variables referenced anywhere in ``phenotypicFilter`` are returned
     as output columns automatically; ``includeConcepts`` names *additional*
-    columns beyond those (ALS-11934).
+    columns beyond those.
 
     A ``genomicFilter`` field is anticipated here in the future, alongside
     ``phenotypicFilter``.

--- a/src/picsure/_models/query.py
+++ b/src/picsure/_models/query.py
@@ -14,7 +14,12 @@ class Query:
     ``None`` for an include-only query (return the named concepts for all
     matching records). Bare ``Clause`` / ``ClauseGroup`` objects are still
     accepted directly by ``Session.runQuery()`` and friends — they mean
-    "filter, no extra output columns."
+    "filter, returning the filtered variables as output columns and no
+    others."
+
+    The variables referenced anywhere in ``phenotypicFilter`` are returned
+    as output columns automatically; ``includeConcepts`` names *additional*
+    columns beyond those (ALS-11934).
 
     A ``genomicFilter`` field is anticipated here in the future, alongside
     ``phenotypicFilter``.

--- a/src/picsure/_models/session.py
+++ b/src/picsure/_models/session.py
@@ -250,8 +250,9 @@ class Session:
 
         Args:
             query: A Query (from buildQuery), or a bare Clause/ClauseGroup
-                (from buildClause/buildClauseGroup) for a filter with no
-                explicitly-included output concepts.
+                (from buildClause/buildClauseGroup). Variables referenced in
+                the filter are returned as output columns automatically;
+                ``includeConcepts`` adds further non-filtered columns.
             type: Result type. Pass either a :class:`QueryType` member
                 (e.g. ``QueryType.COUNT``) or one of the strings:
 

--- a/src/picsure/_services/query_build.py
+++ b/src/picsure/_services/query_build.py
@@ -34,8 +34,9 @@ def buildClause(  # noqa: N802
         PicSureValidationError: If the clause configuration is invalid.
 
     Note:
-        To include concept paths in the query output without filtering, use
-        ``buildQuery(includeConcepts=...)`` — output columns are no longer a
+        Variables you filter on are returned as output columns automatically.
+        To include *additional* concept paths in the output without filtering,
+        use ``buildQuery(includeConcepts=...)`` — output columns are not a
         clause type.
 
     Example:
@@ -142,8 +143,10 @@ def buildQuery(  # noqa: N802
         phenotypicFilter: A Clause or ClauseGroup (from ``buildClause()`` /
             ``buildClauseGroup()``) to filter on, or ``None`` for an
             include-only query.
-        includeConcepts: Concept path(s) to include as output columns. Order
-            is preserved and duplicates are dropped.
+        includeConcepts: *Additional* concept path(s) to include as output
+            columns, beyond the variables already named in
+            ``phenotypicFilter`` — those are returned automatically. Order is
+            preserved and duplicates are dropped.
 
     Returns:
         A Query suitable for ``Session.runQuery()``, ``Session.exportAsPFB()``,

--- a/src/picsure/_services/query_run.py
+++ b/src/picsure/_services/query_run.py
@@ -151,15 +151,29 @@ def build_query_body(
 def _split(
     query: Query | Clause | ClauseGroup,
 ) -> tuple[Clause | ClauseGroup | None, list[str]]:
-    """Normalize a runnable query into a (filter tree, select paths) pair."""
+    """Normalize a runnable query into a (filter tree, select paths) pair.
+
+    Every concept path referenced in the filter tree is folded into the
+    select paths, so a query's filter variables are returned as output
+    columns without being repeated in ``includeConcepts`` (ALS-11934).
+    Explicit ``includeConcepts`` keep their position; filter-derived paths
+    are appended in tree-traversal order; duplicates are dropped.
+    """
     if isinstance(query, Query):
-        return query.phenotypicFilter, list(query.includeConcepts)
-    if isinstance(query, (Clause, ClauseGroup)):
-        return query, []
-    raise PicSureValidationError(
-        "Query must be a Clause, ClauseGroup, or Query. Use "
-        "buildClause()/buildClauseGroup()/buildQuery() to construct one."
-    )
+        filter_tree: Clause | ClauseGroup | None = query.phenotypicFilter
+        select = list(query.includeConcepts)
+    elif isinstance(query, (Clause, ClauseGroup)):
+        filter_tree = query
+        select = []
+    else:
+        raise PicSureValidationError(
+            "Query must be a Clause, ClauseGroup, or Query. Use "
+            "buildClause()/buildClauseGroup()/buildQuery() to construct one."
+        )
+
+    if filter_tree is not None:
+        select.extend(filter_tree.concept_paths())
+    return filter_tree, list(dict.fromkeys(select))
 
 
 def _resolve_query_type(query_type: QueryType | str) -> str:

--- a/src/picsure/_services/query_run.py
+++ b/src/picsure/_services/query_run.py
@@ -155,7 +155,7 @@ def _split(
 
     Every concept path referenced in the filter tree is folded into the
     select paths, so a query's filter variables are returned as output
-    columns without being repeated in ``includeConcepts`` (ALS-11934).
+    columns without being repeated in ``includeConcepts``.
     Explicit ``includeConcepts`` keep their position; filter-derived paths
     are appended in tree-traversal order; duplicates are dropped.
     """

--- a/tests/unit/test_clause.py
+++ b/tests/unit/test_clause.py
@@ -141,6 +141,29 @@ class TestClauseToQueryJson:
         assert leaf_a["phenotypicFilterType"] == "ANY_RECORD_OF"
 
 
+class TestClauseConceptPaths:
+    def test_single_key_returns_that_path(self):
+        clause = Clause(
+            keys=["\\phs1\\sex\\"],
+            type=PhenotypicFilterType.FILTER,
+            categories=["Male"],
+        )
+        assert clause.concept_paths() == ["\\phs1\\sex\\"]
+
+    def test_multi_key_returns_all_paths_in_order(self):
+        clause = Clause(
+            keys=["\\path_a\\", "\\path_b\\"],
+            type=PhenotypicFilterType.ANYRECORD,
+        )
+        assert clause.concept_paths() == ["\\path_a\\", "\\path_b\\"]
+
+    def test_returns_a_copy_not_the_keys_list(self):
+        clause = Clause(keys=["\\p\\"], type=PhenotypicFilterType.REQUIRE)
+        paths = clause.concept_paths()
+        paths.append("\\extra\\")
+        assert clause.keys == ["\\p\\"]
+
+
 class TestBuildClauseDefensiveCopies:
     def test_mutating_keys_list_after_construction_does_not_affect_clause(self):
         keys = ["\\p1\\", "\\p2\\"]

--- a/tests/unit/test_clause_group.py
+++ b/tests/unit/test_clause_group.py
@@ -81,6 +81,43 @@ class TestClauseGroup:
         assert isinstance(outer.clauses[2], ClauseGroup)
 
 
+class TestClauseGroupConceptPaths:
+    def test_flat_group_returns_paths_in_order(self):
+        group = ClauseGroup(
+            clauses=[_sex_clause(), _age_clause()],
+            operator=GroupOperator.AND,
+        )
+        assert group.concept_paths() == ["\\phs1\\sex\\", "\\phs1\\age\\"]
+
+    def test_nested_group_flattens_depth_first_in_order(self):
+        inner = ClauseGroup(
+            clauses=[_copd_clause(), _asthma_clause()],
+            operator=GroupOperator.OR,
+        )
+        outer = ClauseGroup(
+            clauses=[_sex_clause(), _age_clause(), inner],
+            operator=GroupOperator.AND,
+        )
+        assert outer.concept_paths() == [
+            "\\phs1\\sex\\",
+            "\\phs1\\age\\",
+            "\\phs1\\copd\\",
+            "\\phs1\\asthma\\",
+        ]
+
+    def test_multi_key_clause_contributes_all_keys(self):
+        multi = Clause(
+            keys=["\\path_a\\", "\\path_b\\"],
+            type=PhenotypicFilterType.ANYRECORD,
+        )
+        group = ClauseGroup(clauses=[_sex_clause(), multi], operator=GroupOperator.AND)
+        assert group.concept_paths() == [
+            "\\phs1\\sex\\",
+            "\\path_a\\",
+            "\\path_b\\",
+        ]
+
+
 class TestClauseGroupToQueryJson:
     def test_simple_and_group(self):
         group = ClauseGroup(

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -105,7 +105,7 @@ class TestExportPFBHappyPath:
         assert body["query"]["expectedResultType"] == "DATAFRAME_PFB"
         assert body["resourceUUID"] == RESOURCE_UUID
         # The filter variable is returned as a PFB column without being
-        # repeated in includeConcepts (ALS-11934).
+        # repeated in includeConcepts.
         assert body["query"]["select"] == ["\\phs1\\sex\\"]
 
 

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -104,6 +104,9 @@ class TestExportPFBHappyPath:
         body = json.loads(submit_route.calls[0].request.content)
         assert body["query"]["expectedResultType"] == "DATAFRAME_PFB"
         assert body["resourceUUID"] == RESOURCE_UUID
+        # The filter variable is returned as a PFB column without being
+        # repeated in includeConcepts (ALS-11934).
+        assert body["query"]["select"] == ["\\phs1\\sex\\"]
 
 
 class TestExportPFBBackoff:

--- a/tests/unit/test_query_run.py
+++ b/tests/unit/test_query_run.py
@@ -63,7 +63,7 @@ class TestRunQueryCount:
         assert query["expectedResultType"] == "COUNT"
         # The clause's own concept path is folded into ``select`` so a
         # query's filter variables are returned without being repeated in
-        # includeConcepts (ALS-11934).
+        # includeConcepts.
         assert query["select"] == ["\\phs1\\sex\\"]
         assert query["genomicFilters"] == []
         assert query["picsureId"] is None
@@ -273,7 +273,7 @@ class TestRunQueryCrossCount:
     def test_cross_count_body_includes_filter_concepts(self):
         # cross_count flows through the same select-folding, so the filter
         # variable lands in the wire select and is therefore cross-counted
-        # alongside any includeConcepts (ALS-11934).
+        # alongside any includeConcepts.
         route = respx.post(QUERY_URL).mock(
             return_value=httpx.Response(200, content=b'{"\\\\phs1\\\\sex\\\\": "42"}')
         )
@@ -426,7 +426,7 @@ class TestRunQueryWithClauseGroup:
         # A Query carrying both a phenotypic filter and includeConcepts lifts
         # the concepts to the top-level ``select`` array and serializes the
         # filter as ``phenotypicClause``. The filter's own concept path is
-        # appended after the explicit includeConcepts (ALS-11934).
+        # appended after the explicit includeConcepts.
         route = respx.post(QUERY_URL).mock(
             return_value=httpx.Response(200, content=b"100")
         )
@@ -464,7 +464,7 @@ class TestRunQueryWithClauseGroup:
     def test_bare_clause_selects_filter_concepts(self):
         # A bare clause with no includeConcepts still returns its filtered
         # variable as an output column — previously this select was empty
-        # and only the participant ID came back (ALS-11934).
+        # and only the participant ID came back.
         route = respx.post(QUERY_URL).mock(
             return_value=httpx.Response(200, content=b"100")
         )
@@ -479,7 +479,7 @@ class TestRunQueryWithClauseGroup:
 
 
 class TestSelectIncludesFilterConcepts:
-    """ALS-11934: filter variables are returned without includeConcepts."""
+    """Filter variables are returned as output columns without includeConcepts."""
 
     def _select_for(self, query) -> list[str]:
         route = respx.post(QUERY_URL).mock(

--- a/tests/unit/test_query_run.py
+++ b/tests/unit/test_query_run.py
@@ -61,7 +61,10 @@ class TestRunQueryCount:
         assert body["resourceUUID"] == RESOURCE_UUID
         query = body["query"]
         assert query["expectedResultType"] == "COUNT"
-        assert query["select"] == []
+        # The clause's own concept path is folded into ``select`` so a
+        # query's filter variables are returned without being repeated in
+        # includeConcepts (ALS-11934).
+        assert query["select"] == ["\\phs1\\sex\\"]
         assert query["genomicFilters"] == []
         assert query["picsureId"] is None
         assert query["id"] is None
@@ -407,7 +410,8 @@ class TestRunQueryWithClauseGroup:
     def test_query_with_filter_and_include_concepts(self):
         # A Query carrying both a phenotypic filter and includeConcepts lifts
         # the concepts to the top-level ``select`` array and serializes the
-        # filter as ``phenotypicClause``.
+        # filter as ``phenotypicClause``. The filter's own concept path is
+        # appended after the explicit includeConcepts (ALS-11934).
         route = respx.post(QUERY_URL).mock(
             return_value=httpx.Response(200, content=b"100")
         )
@@ -421,7 +425,7 @@ class TestRunQueryWithClauseGroup:
         import json
 
         body = json.loads(route.calls[0].request.content)
-        assert body["query"]["select"] == ["\\out_a\\", "\\out_b\\"]
+        assert body["query"]["select"] == ["\\out_a\\", "\\out_b\\", "\\phs1\\sex\\"]
         pheno = body["query"]["phenotypicClause"]
         assert pheno is not None
         assert pheno["phenotypicFilterType"] == "FILTER"
@@ -442,7 +446,10 @@ class TestRunQueryWithClauseGroup:
         assert body["query"]["select"] == ["\\a\\", "\\b\\"]
 
     @respx.mock
-    def test_bare_clause_has_empty_select(self):
+    def test_bare_clause_selects_filter_concepts(self):
+        # A bare clause with no includeConcepts still returns its filtered
+        # variable as an output column — previously this select was empty
+        # and only the participant ID came back (ALS-11934).
         route = respx.post(QUERY_URL).mock(
             return_value=httpx.Response(200, content=b"100")
         )
@@ -452,8 +459,66 @@ class TestRunQueryWithClauseGroup:
         import json
 
         body = json.loads(route.calls[0].request.content)
-        assert body["query"]["select"] == []
+        assert body["query"]["select"] == ["\\phs1\\sex\\"]
         assert body["query"]["phenotypicClause"] is not None
+
+
+class TestSelectIncludesFilterConcepts:
+    """ALS-11934: filter variables are returned without includeConcepts."""
+
+    def _select_for(self, query) -> list[str]:
+        route = respx.post(QUERY_URL).mock(
+            return_value=httpx.Response(200, content=b"1")
+        )
+        run_query(_make_client(), RESOURCE_UUID, query, "participant")
+
+        import json
+
+        return json.loads(route.calls[0].request.content)["query"]["select"]
+
+    @respx.mock
+    def test_bare_clause_group_selects_all_filter_concepts(self):
+        age = Clause(keys=["\\age\\"], type=PhenotypicFilterType.FILTER, min=40.0)
+        group = ClauseGroup(clauses=[_simple_clause(), age], operator=GroupOperator.AND)
+        assert self._select_for(group) == ["\\phs1\\sex\\", "\\age\\"]
+
+    @respx.mock
+    def test_nested_group_collects_every_path_in_order(self):
+        age = Clause(keys=["\\age\\"], type=PhenotypicFilterType.FILTER, min=40.0)
+        bmi = Clause(keys=["\\bmi\\"], type=PhenotypicFilterType.FILTER, min=18.0)
+        inner = ClauseGroup(clauses=[age, bmi], operator=GroupOperator.OR)
+        outer = ClauseGroup(
+            clauses=[_simple_clause(), inner], operator=GroupOperator.AND
+        )
+        assert self._select_for(outer) == ["\\phs1\\sex\\", "\\age\\", "\\bmi\\"]
+
+    @respx.mock
+    def test_multi_key_clause_contributes_all_keys(self):
+        multi = Clause(keys=["\\a\\", "\\b\\"], type=PhenotypicFilterType.ANYRECORD)
+        assert self._select_for(multi) == ["\\a\\", "\\b\\"]
+
+    @respx.mock
+    def test_include_concepts_come_first_then_filter_vars(self):
+        query = Query(
+            phenotypicFilter=_simple_clause(),
+            includeConcepts=("\\out_a\\",),
+        )
+        assert self._select_for(query) == ["\\out_a\\", "\\phs1\\sex\\"]
+
+    @respx.mock
+    def test_overlap_is_deduped_keeping_include_concept_slot(self):
+        # The filtered path is also explicitly included; it must appear once,
+        # in its includeConcepts position, not be appended a second time.
+        query = Query(
+            phenotypicFilter=_simple_clause(),
+            includeConcepts=("\\phs1\\sex\\", "\\out_b\\"),
+        )
+        assert self._select_for(query) == ["\\phs1\\sex\\", "\\out_b\\"]
+
+    @respx.mock
+    def test_include_only_query_unaffected(self):
+        query = Query(includeConcepts=("\\a\\", "\\b\\"))
+        assert self._select_for(query) == ["\\a\\", "\\b\\"]
 
 
 class TestRunQueryValidation:

--- a/tests/unit/test_query_run.py
+++ b/tests/unit/test_query_run.py
@@ -270,6 +270,21 @@ class TestRunQueryCrossCount:
         assert body["query"]["expectedResultType"] == "CROSS_COUNT"
 
     @respx.mock
+    def test_cross_count_body_includes_filter_concepts(self):
+        # cross_count flows through the same select-folding, so the filter
+        # variable lands in the wire select and is therefore cross-counted
+        # alongside any includeConcepts (ALS-11934).
+        route = respx.post(QUERY_URL).mock(
+            return_value=httpx.Response(200, content=b'{"\\\\phs1\\\\sex\\\\": "42"}')
+        )
+        run_query(_make_client(), RESOURCE_UUID, _simple_clause(), "cross_count")
+
+        import json
+
+        body = json.loads(route.calls[0].request.content)
+        assert body["query"]["select"] == ["\\phs1\\sex\\"]
+
+    @respx.mock
     def test_returns_dict_of_count_results(self):
         # Mirrors the real server shape: concept_path -> count string.
         # Includes one of each count shape (exact, noisy, suppressed).
@@ -506,14 +521,25 @@ class TestSelectIncludesFilterConcepts:
         assert self._select_for(query) == ["\\out_a\\", "\\phs1\\sex\\"]
 
     @respx.mock
-    def test_overlap_is_deduped_keeping_include_concept_slot(self):
-        # The filtered path is also explicitly included; it must appear once,
-        # in its includeConcepts position, not be appended a second time.
-        query = Query(
-            phenotypicFilter=_simple_clause(),
-            includeConcepts=("\\phs1\\sex\\", "\\out_b\\"),
-        )
-        assert self._select_for(query) == ["\\phs1\\sex\\", "\\out_b\\"]
+    def test_overlap_is_deduped_and_filter_only_var_appended(self):
+        # The group filters on sex AND age; age is also explicitly included.
+        # age must appear once in its includeConcepts slot (dedup), while the
+        # filter-only sex var is appended after — so both the append and the
+        # dedup are load-bearing (the assertion fails if either is dropped).
+        age = Clause(keys=["\\age\\"], type=PhenotypicFilterType.FILTER, min=40.0)
+        group = ClauseGroup(clauses=[_simple_clause(), age], operator=GroupOperator.AND)
+        query = Query(phenotypicFilter=group, includeConcepts=("\\age\\", "\\out_b\\"))
+        assert self._select_for(query) == ["\\age\\", "\\out_b\\", "\\phs1\\sex\\"]
+
+    @respx.mock
+    def test_duplicate_path_across_clauses_is_deduped(self):
+        # Two clauses filter the SAME concept path (age > 40 AND age < 80).
+        # The path must appear only once in select — this is the case the
+        # dict.fromkeys dedup in _split() exists to collapse.
+        low = Clause(keys=["\\age\\"], type=PhenotypicFilterType.FILTER, min=40.0)
+        high = Clause(keys=["\\age\\"], type=PhenotypicFilterType.FILTER, max=80.0)
+        group = ClauseGroup(clauses=[low, high], operator=GroupOperator.AND)
+        assert self._select_for(group) == ["\\age\\"]
 
     @respx.mock
     def test_include_only_query_unaffected(self):


### PR DESCRIPTION
## Summary

Resolves [ALS-11934](https://hms-dbmi.atlassian.net/browse/ALS-11934).

A query now returns **every variable referenced in its filter clauses** as an output column automatically — without requiring those paths to be repeated in `includeConcepts`. Previously, a filter with an empty `includeConcepts` returned only the participant ID.

## Approach

- `Clause.concept_paths()` / `ClauseGroup.concept_paths()` collect the concept paths referenced anywhere in a filter tree (mirrors the existing `to_query_json()` pattern).
- `query_run._split()` folds those paths into the wire `select` array — explicit `includeConcepts` keep their position first, filter variables are appended in tree order, duplicates dropped. Because `_split()` feeds `build_query_body()`, the change covers `runQuery` (all result types), `exportAsPFB`, and `saveQueryByName` in one place.

### Decisions
- **Uniform across all result types** (no per-type branching). `count` ignores `select`; `cross_count` now also cross-counts the filter variables (consistent — they're part of the query).
- **No opt-out flag** — auto-inclusion is unconditional; a column can be dropped client-side from the resulting DataFrame.

## Behavior

| Query shape | `select` before | `select` after |
| --- | --- | --- |
| Bare `Clause` on `\a\` | `[]` | `["\a\"]` |
| `Query(filter=\a\, includeConcepts=["\c\"])` | `["\c\"]` | `["\c\", "\a\"]` |
| `Query(filter=\a\, includeConcepts=["\a\"])` | `["\a\"]` | `["\a\"]` (de-duped) |
| Include-only `Query` (`filter=None`) | `["\c\"]` | `["\c\"]` (unchanged) |

## Test plan
- `ruff check` / `ruff format --check`: clean
- `mypy src/`: no issues
- `pytest`: 542 passed, 17 skipped (new `concept_paths()` unit tests; new `TestSelectIncludesFilterConcepts`; updated count/include-concept body assertions)

## Notes
- R adapter needs no code change (the reticulate wrapper forwards args 1:1); a companion PR refreshes the R docstrings.
- Worth a live `cross_count` check on BDC before merge to confirm the extra `select` entries extend the result dict as expected.