### PR TITLE
Add tag-triggered PyPI release workflow (hatch-vcs dynamic versioning)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # hatch-vcs reads git history/tags for the version
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
@@ -26,6 +28,8 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # hatch-vcs reads git history/tags for the version
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # hatch-vcs reads git history/tags for the version
 
       - uses: astral-sh/setup-uv@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,134 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+# Least privilege by default; jobs opt into what they need.
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # hatch-vcs reads git history/tags for the version
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - run: uv sync --frozen
+      - run: uv run ruff check src/ tests/
+      - run: uv run ruff format --check src/ tests/
+      - run: uv run mypy src/
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - run: uv python install ${{ matrix.python-version }}
+      - run: uv sync --frozen --python ${{ matrix.python-version }}
+      - run: uv run pytest tests/unit/ -v --cov=picsure --cov-fail-under=80
+
+  build:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    outputs:
+      prerelease: ${{ steps.classify.outputs.prerelease }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required: full history + tags so hatch-vcs derives the tagged version
+
+      - name: Classify tag (final vs pre-release)
+        id: classify
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "Final release: $tag -> PyPI"
+          elif [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "Pre-release: $tag -> TestPyPI"
+          else
+            echo "::error::Tag '$tag' is not vMAJOR.MINOR.PATCH or a PEP 440 pre-release (e.g. v2.0.0, v2.0.0rc1)"
+            exit 1
+          fi
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Build sdist + wheel
+        run: uv build
+
+      - name: Check distribution metadata
+        run: uvx twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-testpypi:
+    needs: build
+    if: needs.build.outputs.prerelease == 'true'
+    runs-on: ubuntu-latest
+    environment: TestPyPi
+    permissions:
+      id-token: write # OIDC token for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    needs: build
+    if: needs.build.outputs.prerelease == 'false'
+    runs-on: ubuntu-latest
+    environment: PyPi
+    permissions:
+      id-token: write # OIDC token for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    needs: [build, publish-pypi, publish-testpypi]
+    # Run once whichever publish job for this tag has succeeded.
+    if: always() && (needs.publish-pypi.result == 'success' || needs.publish-testpypi.result == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub Release + upload assets
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            ${{ needs.build.outputs.prerelease == 'true' && '--prerelease' || '' }} \
+            dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "picsure"
-version = "2.0.0"
+dynamic = ["version"]
 description = "Python client for the PIC-SURE API"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -38,8 +38,11 @@ notebook = [
 ]
 
 [build-system]
-requires = ["hatchling>=1.21"]
+requires = ["hatchling>=1.21", "hatch-vcs>=0.4"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/picsure"]

--- a/uv.lock
+++ b/uv.lock
@@ -2775,7 +2775,6 @@ wheels = [
 
 [[package]]
 name = "picsure"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro" },


### PR DESCRIPTION
## What

Adds automated PyPI publishing triggered by version tags, and switches the package version to be **derived from the git tag** (single source of truth).

Push a `vX.Y.Z` tag → the package is built, checked, and published to PyPI; a GitHub Release is created with the artifacts attached.

## Changes

- **`build:` dynamic version via `hatch-vcs`** — `pyproject.toml` `version` is now `dynamic` (sourced from VCS) instead of a hardcoded literal; `uv.lock` regenerated (picsure recorded as dynamic). The tag *is* the version: `v2.0.0` → `2.0.0`, `v2.0.0rc1` → `2.0.0rc1`.
- **`ci:` `fetch-depth: 0`** added to `ci.yml` + `docs.yml` checkouts — every `uv sync`/build now invokes hatch-vcs, which needs full history/tags (otherwise it warns on the shallow default checkout).
- **`ci:` new `release.yml`**:
  - Trigger: `push` of tags matching `v*`.
  - `lint` + `test` (3.10/3.11/3.12, cov ≥ 80%) → `build` (`uv build` + `twine check`, uploads the artifact once).
  - Routing: final tags (`vX.Y.Z`) → **PyPI**; PEP 440 pre-release tags (`vX.Y.ZrcN`/`bN`/`aN`) → **TestPyPI**. Malformed tags fail fast.
  - Publishing uses **PyPI Trusted Publishing (OIDC)** — no API token stored. Each publish job runs in a protected environment (`PyPi` / `TestPyPi`).
  - Finishes by creating a GitHub Release with the built sdist + wheel attached.

## Required manual setup before the first release

1. Create the `PyPi` and `TestPyPi` GitHub Environments.
2. Register **pending** Trusted Publishers on PyPI and TestPyPI: project `picsure`, owner `hms-dbmi`, repo `pic-sure-python-adapter-hpds`, workflow `release.yml`, environment `PyPi` / `TestPyPi` respectively.

## Verification (local)

- `ruff check` / `ruff format --check` / `mypy` — clean
- `pytest tests/unit/` — 544 passed, 95.74% coverage
- `uv sync --frozen` works with the regenerated lock
- Tag→version: a throwaway local `v2.0.0` tag built `picsure-2.0.0` and `twine check` PASSED (tag deleted, not pushed)

## Suggested rollout

Merge → dry-run with a `v2.0.0rc1` tag (lands on TestPyPI) → then cut `v2.0.0`.
