### PR TITLE
ci: accept pre-release tags without a trailing number (fix release build)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,11 @@ jobs:
           if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
             echo "Final release: $tag -> PyPI"
-          elif [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]]; then
+          elif [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]*$ ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
             echo "Pre-release: $tag -> TestPyPI"
           else
-            echo "::error::Tag '$tag' is not vMAJOR.MINOR.PATCH or a PEP 440 pre-release (e.g. v2.0.0, v2.0.0rc1)"
+            echo "::error::Tag '$tag' is not vMAJOR.MINOR.PATCH or a PEP 440 pre-release (e.g. v2.0.0, v2.0.0rc1, v2.0.0rc)"
             exit 1
           fi
 


### PR DESCRIPTION
## Problem

The `v2.0.0rc` tag failed the release run ([run 27630833929](https://github.com/hms-dbmi/pic-sure-python-adapter-hpds/actions/runs/27630833929)) at the `build → Classify tag` step. The pre-release regex required a digit after `a`/`b`/`rc`, so `v2.0.0rc` was rejected — even though it's valid PEP 440 (normalizes to `2.0.0rc0`).

No publish occurred: `build` fails before any publish job runs.

## Fix

Make the trailing number optional: `(a|b|rc)[0-9]+` → `(a|b|rc)[0-9]*`. Now both `v2.0.0rc` and `v2.0.0rc1` route to TestPyPI. Final tags and garbage tags are unaffected.

Verified locally against a tag battery:

| tag | result |
|---|---|
| `v2.0.0` | final → PyPI |
| `v2.0.0rc`, `v2.0.0rc1`, `v2.0.0b1`, `v2.0.0a0` | pre-release → TestPyPI |
| `v2.0`, `vfoo`, `v2.0.0-rc1`, `v2.0.0beta` | rejected (fail fast) |

## After merge

The existing `v2.0.0rc` tag points at the old commit. To dry-run with the fix, push a fresh tag on updated `main` (e.g. `v2.0.0rc1`).
