### PR TITLE
ci: stop auto-creating the GitHub Release (write notes manually)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,26 +109,3 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
-
-  github-release:
-    needs: [build, publish-pypi, publish-testpypi]
-    # Run once whichever publish job for this tag has succeeded.
-    if: always() && (needs.publish-pypi.result == 'success' || needs.publish-testpypi.result == 'success')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # create the GitHub Release + upload assets
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "${GITHUB_REF_NAME}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --title "${GITHUB_REF_NAME}" \
-            --generate-notes \
-            ${{ needs.build.outputs.prerelease == 'true' && '--prerelease' || '' }} \
-            dist/*


### PR DESCRIPTION
## What

Removes the `github-release` job from `release.yml`. The release workflow now ends after publishing to PyPI / TestPyPI; we create the GitHub Release **manually** so we can write our own release notes instead of auto-generating them.

## Why

PyPI is the actual distribution channel — the GitHub Release is just human-facing notes/changelog, which we want to author by hand.

## Effect

- `release.yml` jobs are now: `lint` → `test` → `build` → (`publish-testpypi` | `publish-pypi`).
- No GitHub Release is created automatically, and the built sdist/wheel are no longer auto-attached to a release. The artifacts are still available on PyPI, and also as the workflow run's `dist` artifact if you want to attach them to a manual release.
- `build.outputs.prerelease` is retained — it still routes pre-release vs final to the correct index.

No change to versioning, publishing, or Trusted Publishing.
