### PR TITLE
docs(notebooks): use NHANES_AUTHORIZED instead of BDC_AUTHORIZED

### DIFF
--- a/notebooks/0_Connect.ipynb
+++ b/notebooks/0_Connect.ipynb
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "authorized_session = picsure.connect(\n",
-    "    picsure.Platform.BDC_AUTHORIZED,\n",
+    "    picsure.Platform.NHANES_AUTHORIZED,\n",
     "    my_token\n",
     ")"
    ]

--- a/notebooks/1_Search.ipynb
+++ b/notebooks/1_Search.ipynb
@@ -26,7 +26,7 @@
    "cell_type": "code",
    "source": [
     "authorized_session = picsure.connect(\n",
-    "    picsure.Platform.BDC_AUTHORIZED,\n",
+    "    picsure.Platform.NHANES_AUTHORIZED,\n",
     "    my_token\n",
     ")"
    ],

--- a/notebooks/2_Query.ipynb
+++ b/notebooks/2_Query.ipynb
@@ -26,7 +26,7 @@
    "cell_type": "code",
    "source": [
     "authorized_session = picsure.connect(\n",
-    "    picsure.Platform.BDC_AUTHORIZED,\n",
+    "    picsure.Platform.NHANES_AUTHORIZED,\n",
     "    my_token,\n",
     "    dev_mode=True\n",
     ")"

--- a/notebooks/5_Load_Query_By_ID.ipynb
+++ b/notebooks/5_Load_Query_By_ID.ipynb
@@ -28,7 +28,7 @@
     "    my_token = f.read()\n",
     "\n",
     "session = picsure.connect(\n",
-    "    picsure.Platform.BDC_AUTHORIZED,\n",
+    "    picsure.Platform.NHANES_AUTHORIZED,\n",
     "    dev_mode=True,\n",
     "    token=my_token\n",
     ")"

--- a/notebooks/6_Run_Query_By_ID.ipynb
+++ b/notebooks/6_Run_Query_By_ID.ipynb
@@ -29,7 +29,7 @@
     "    my_token = f.read()\n",
     "\n",
     "session = picsure.connect(\n",
-    "    picsure.Platform.BDC_AUTHORIZED,\n",
+    "    picsure.Platform.NHANES_AUTHORIZED,\n",
     "    dev_mode=True,\n",
     "    token=my_token\n",
     ")"

--- a/notebooks/7_Export_Query_As_PFB.ipynb
+++ b/notebooks/7_Export_Query_As_PFB.ipynb
@@ -22,7 +22,7 @@
     "    my_token = f.read()\n",
     "\n",
     "session = picsure.connect(\n",
-    "    platform=picsure.Platform.BDC_AUTHORIZED,\n",
+    "    platform=picsure.Platform.NHANES_AUTHORIZED,\n",
     "    token=my_token,\n",
     "    dev_mode=True,\n",
     ")"

--- a/notebooks/9_Save_Query_By_Name.ipynb
+++ b/notebooks/9_Save_Query_By_Name.ipynb
@@ -23,7 +23,7 @@
     "    my_token = f.read().strip()\n",
     "\n",
     "auth_hpds_session = picsure.connect(\n",
-    "    picsure.Platform.BDC_AUTHORIZED,\n",
+    "    picsure.Platform.NHANES_AUTHORIZED,\n",
     "    token=my_token,\n",
     "    dev_mode=True\n",
     ")"


### PR DESCRIPTION
## What

Switch the **authorized** connection examples in the Python adapter notebooks from `Platform.BDC_AUTHORIZED` to `Platform.NHANES_AUTHORIZED`.

7 notebooks updated (one line each): `0_Connect`, `1_Search`, `2_Query`, `5_Load_Query_By_ID`, `6_Run_Query_By_ID`, `7_Export_Query_As_PFB`, `9_Save_Query_By_Name`.

## Notes

- `NHANES_AUTHORIZED` is a valid `Platform` enum member, so the examples remain runnable.
- **`BDC_OPEN` left unchanged** in the open-access notebooks (`3_Open_Query`, `4_Complex_Open_Queries`, `8_Remove_and_Replace_Query_Functions`, and the open example in `0_Connect`) — that's a different platform and wasn't part of this request. Say the word if you want those moved to `NHANES_OPEN` too.
- The notebooks don't hardcode any BDC-specific concept paths, so nothing else needed changing for the queries to make sense on NHANES.
- `0_Connect.ipynb` had stray local execution outputs (including an email + token expiry); those were dropped so the diff is purely the platform swap.
