### PR TITLE
refactor(docs, services): streamline dictionary search and `connect()…

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -100,8 +100,8 @@ src/picsure/
 
 | Module           | What it owns                                                                 |
 |------------------|------------------------------------------------------------------------------|
-| `connect.py`     | `connect(platform, token, …)`. Resolves the platform, hits `/psama/user/me` (skipped on open-access), fetches resources, consents, dictionary size, and constructs the `Session`. Also handles the dev-mode toggle and the success/expiration banner. |
-| `search.py`      | `searchDictionary`, `fetch_facets`, `show_all_facets`, plus the smaller helpers that build dictionary-api request bodies, dedupe entries, and turn results into DataFrames. Also `fetch_total_concepts` (used by connect to pre-size search pages). |
+| `connect.py`     | `connect(platform, token, …)`. Resolves the platform, fetches resources and (on authorized deployments) consents, and constructs the `Session`. Reads the display email and expiry straight from the JWT — no `/psama/user/me` round trip. Also handles the dev-mode toggle and the success/expiration banner. |
+| `search.py`      | `searchDictionary`, `fetch_facets`, `show_all_facets`, plus the smaller helpers that build dictionary-api request bodies, dedupe entries, and turn results into DataFrames. Dictionary searches use a single max-int page (`_MAX_PAGE_SIZE`) so one request returns every concept. |
 | `query_build.py` | `buildClause`, `buildClauseGroup`, and `buildQuery` — the public constructors for `Clause`, `ClauseGroup`, and `Query` with input validation (rejects mutually-exclusive arguments before they reach the wire). |
 | `query_edit.py`  | `removeSubQuery(query, target)` and `replaceClause(query, target, replacement)`. Pure local tree edits — no network calls. Matching is structural (frozen-dataclass equality). Removals that empty a `ClauseGroup` prune the parent; removing the whole tree raises `PicSureValidationError`. |
 | `query_run.py`   | `run_query(client, resource_uuid, query, type)`. Serializes via `build_query_body`, posts to the v3 sync endpoint (or the legacy path on open-only deployments), and parses each response shape. Also `parse_count_string` for the obfuscated-count regexes. |
@@ -217,8 +217,6 @@ small:
 - `_consents` — `list[str]` of study-consent identifiers. Empty on
   open-access; required in dictionary-api request bodies on
   authorized deployments.
-- `_total_concepts` — captured at connect time and used as the page
-  size for searches so results come back in one page.
 - `_dev_config` — opt-in `DevConfig` (off by default).
 - `_use_legacy_query_path` — set during connect when the platform is
   open-only and must use `/picsure/query/sync` (BDC's API gateway

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -99,7 +99,6 @@ Complete reference for all public functions, classes, and types in the
     options:
       members:
         - consents
-        - total_concepts
         - searchDictionary
         - facets
         - showAllFacets

--- a/src/picsure/_models/session.py
+++ b/src/picsure/_models/session.py
@@ -38,7 +38,6 @@ class Session:
         resources: list[Resource],
         resource_uuid: str | None = None,
         consents: list[str] | None = None,
-        total_concepts: int = 0,
         dev_config: DevConfig | None = None,
         use_legacy_query_path: bool = False,
         supports_genomic: bool = False,
@@ -51,7 +50,6 @@ class Session:
         self._resource_uuid = resource_uuid
         self._session_id = session_id
         self._consents: list[str] = list(consents) if consents else []
-        self._total_concepts = total_concepts
         self._use_legacy_query_path = use_legacy_query_path
         self._supports_genomic = supports_genomic
         self._dev_config = (
@@ -79,15 +77,6 @@ class Session:
         body so the backend scopes results to accessible studies.
         """
         return list(self._consents)
-
-    @property
-    def total_concepts(self) -> int:
-        """Total number of concepts in the data dictionary.
-
-        Captured at connect time and used as the page size for search
-        requests so every result comes back in one page.
-        """
-        return self._total_concepts
 
     def getResourceID(self) -> pd.DataFrame:
         """Return resource IDs and metadata as a DataFrame."""
@@ -172,7 +161,6 @@ class Session:
             facets=facets,
             include_values=include_values,
             consents=self._consents,
-            page_size=self._total_concepts,
         )
 
     @timed("session.facets")

--- a/src/picsure/_services/connect.py
+++ b/src/picsure/_services/connect.py
@@ -11,28 +11,19 @@ from picsure._dev.config import DevConfig
 from picsure._dev.events import Event
 from picsure._models.resource import Resource
 from picsure._models.session import Session
-from picsure._services._errors import rate_limit_message
 from picsure._services.consents import fetch_consents
-from picsure._services.search import fetch_total_concepts
 from picsure._transport.client import PicSureClient
 from picsure._transport.errors import (
     TransportAuthenticationError,
-    TransportConnectionError,
     TransportError,
-    TransportNotFoundError,
-    TransportRateLimitError,
-    TransportServerError,
-    TransportValidationError,
 )
 from picsure._transport.platforms import Platform, resolve_platform
 from picsure.errors import (
     PicSureAuthError,
     PicSureConnectionError,
-    PicSureQueryError,
     PicSureValidationError,
 )
 
-_PSAMA_PROFILE_PATH = "/psama/user/me"
 _PICSURE_RESOURCES_PATH = "/picsure/info/resources"
 
 _ANONYMOUS_EMAIL = "anonymous"
@@ -71,8 +62,8 @@ def connect(
             ``True`` to fetch the consent list from PSAMA on connect.
         requires_auth: Override the platform's auth requirement.  Known
             Platform members default to their own flag; custom URLs
-            default to ``True``.  Pass ``False`` to skip the PSAMA
-            profile call on an open-access deployment.
+            default to ``True``.  Pass ``False`` on an open-access
+            deployment to connect anonymously without a token.
         supports_genomic: Override whether genomic operations are allowed
             on this session.  Defaults to the platform's own flag (``True``
             for ``Platform.BDC_AUTHORIZED``, ``False`` otherwise).  For
@@ -150,19 +141,17 @@ def connect(
     )
 
     if info.requires_auth:
-        profile = _fetch_profile(client, display_name, info.url)
-        email = str(profile.get("email", "unknown"))
-        # PSAMA's /user/me returns UserForDisplay (uuid, email, privileges,
-        # token, queryScopes, acceptedTOS) — it does not expose token
-        # expiry.  The token itself is a JWT, so read its `exp` claim.
+        # The token is the PSAMA-issued PIC-SURE JWT (built from
+        # UserClaims), so both the display email and the expiry come
+        # straight from its claims — no round trip to /psama/user/me.
+        email = _email_from_jwt(token)
         expiration = _token_expiration_from_jwt(token)
     else:
         email = _ANONYMOUS_EMAIL
         expiration = _ANONYMOUS_EXPIRATION
 
-    resources = _fetch_resources(client, display_name, info.requires_auth)
+    resources = _fetch_resources(client, display_name, info.url, info.requires_auth)
     consents = fetch_consents(client) if info.include_consents else []
-    total_concepts = fetch_total_concepts(client, consents=consents)
 
     # Explicit resource_uuid wins, then Platform default, then None.
     effective_uuid = resource_uuid if resource_uuid is not None else info.resource_uuid
@@ -197,7 +186,6 @@ def connect(
                 metadata={
                     "resources": len(resources),
                     "consents": len(consents),
-                    "total_concepts": total_concepts,
                     "requires_auth": info.requires_auth,
                 },
             )
@@ -217,7 +205,6 @@ def connect(
         resources=resources,
         resource_uuid=effective_uuid,
         consents=consents,
-        total_concepts=total_concepts,
         dev_config=dev_config,
         use_legacy_query_path=use_legacy_query_path,
         supports_genomic=info.supports_genomic,
@@ -225,30 +212,69 @@ def connect(
     )
 
 
-def _token_expiration_from_jwt(token: str) -> str:
-    """Extract the ``exp`` claim from a JWT and format it as UTC ISO.
+def _decode_jwt_payload(token: str) -> dict[str, object] | None:
+    """Decode a JWT's payload segment without verifying the signature.
 
     The signature is intentionally not verified — the server enforces
-    token validity; we only display the expiry to the user.  Returns
-    ``"unknown"`` if the token is not a parseable JWT or has no
-    numeric ``exp`` claim.
+    token validity; we only read display fields (email, expiry) from
+    the payload.  Returns the payload dict, or ``None`` if the token is
+    not a parseable JWT with a JSON-object payload.
     """
     try:
         payload_b64 = token.strip().split(".")[1]
     except IndexError:
-        return "unknown"
+        return None
 
     padding = "=" * (-len(payload_b64) % 4)
     try:
         payload = json.loads(base64.urlsafe_b64decode(payload_b64 + padding))
     except (ValueError, TypeError):
+        return None
+
+    return payload if isinstance(payload, dict) else None
+
+
+def _token_expiration_from_jwt(token: str) -> str:
+    """Extract the ``exp`` claim from a JWT and format it as UTC ISO.
+
+    Returns ``"unknown"`` if the token is not a parseable JWT or has no
+    numeric ``exp`` claim.
+    """
+    payload = _decode_jwt_payload(token)
+    if payload is None:
         return "unknown"
 
-    exp = payload.get("exp") if isinstance(payload, dict) else None
+    exp = payload.get("exp")
     if not isinstance(exp, (int, float)) or isinstance(exp, bool):
         return "unknown"
 
     return datetime.fromtimestamp(exp, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# Preference order for the display email in the connect banner.  PSAMA
+# builds the PIC-SURE token from UserClaims, which carries ``email``
+# (plus ``preferred_username`` and ``sub``).  ``email`` is not immutable
+# per RAS guidance, but we only display it, so degrade gracefully to
+# progressively less specific claims rather than fail the connect.
+_EMAIL_CLAIMS = ("email", "preferred_username", "sub")
+
+
+def _email_from_jwt(token: str) -> str:
+    """Read a display email from the JWT the user supplied.
+
+    Falls back through :data:`_EMAIL_CLAIMS` and finally to ``"unknown"``
+    if none is present, so the connect banner never breaks on a token
+    whose claims vary by IdP / Okta mapping.
+    """
+    payload = _decode_jwt_payload(token)
+    if payload is None:
+        return "unknown"
+
+    for claim in _EMAIL_CLAIMS:
+        value = payload.get(claim)
+        if isinstance(value, str) and value.strip():
+            return value
+    return "unknown"
 
 
 def _install_default_handler() -> None:
@@ -266,49 +292,24 @@ def _install_default_handler() -> None:
     logger.setLevel(logging.DEBUG)
 
 
-def _fetch_profile(
-    client: PicSureClient, display_name: str, base_url: str
-) -> dict[str, object]:
-    try:
-        return client.get_json(_PSAMA_PROFILE_PATH)
-    except TransportAuthenticationError as exc:
-        raise PicSureAuthError(
-            "Your token is invalid or expired. Generate a new one at "
-            f"{base_url} and pass it to picsure.connect()."
-        ) from exc
-    except TransportNotFoundError as exc:
-        raise PicSureQueryError(
-            f"Profile endpoint not found at {base_url}. The server may not "
-            "support this adapter version."
-        ) from exc
-    except TransportValidationError as exc:
-        raise PicSureValidationError(
-            f"Server rejected the profile request (HTTP {exc.status_code}): "
-            f"{exc.body[:200]}"
-        ) from exc
-    except TransportRateLimitError as exc:
-        raise PicSureConnectionError(
-            rate_limit_message(exc, suffix=f" by {display_name}")
-        ) from exc
-    except (TransportConnectionError, TransportServerError) as exc:
-        raise PicSureConnectionError(
-            f"Could not reach {display_name} ({base_url}). Check your internet "
-            "connection, or try a different platform."
-        ) from exc
-
-
 def _fetch_resources(
-    client: PicSureClient, display_name: str, requires_auth: bool
+    client: PicSureClient, display_name: str, base_url: str, requires_auth: bool
 ) -> list[Resource]:
     try:
         data = client.get_json(_PICSURE_RESOURCES_PATH)
-    except TransportAuthenticationError:
+    except TransportAuthenticationError as exc:
         # Open-access deployments may gate /info/resources behind auth
         # even though the dictionary-api is public.  Silently degrade
         # to no resources so search/facets still work.
         if not requires_auth:
             return []
-        raise
+        # On auth deployments this is the first authenticated call, so
+        # it owns the friendly "your token is bad" message that the
+        # /psama/user/me handshake used to surface.
+        raise PicSureAuthError(
+            "Your token is invalid or expired. Generate a new one at "
+            f"{base_url} and pass it to picsure.connect()."
+        ) from exc
     except TransportError as exc:
         raise PicSureConnectionError(
             f"Connected to {display_name} but could not fetch resources. "

--- a/src/picsure/_services/search.py
+++ b/src/picsure/_services/search.py
@@ -23,6 +23,11 @@ from picsure.errors import (
 _CONCEPTS_PATH = "/picsure/proxy/dictionary-api/concepts"
 _FACETS_PATH = "/picsure/proxy/dictionary-api/facets"
 
+# Page size for the "one big page" dictionary search.  Set to Java
+# ``Integer.MAX_VALUE`` (the backend's int width) so a single request
+# returns every concept the user can see, without a prior count probe.
+_MAX_PAGE_SIZE = 2_147_483_647
+
 _COLUMNS_WITH_VALUES = [
     "conceptPath",
     "name",
@@ -69,47 +74,6 @@ def _translate_dictionary_4xx(
     )
 
 
-def fetch_total_concepts(
-    client: PicSureClient,
-    consents: list[str] | None = None,
-) -> int:
-    """Probe the concepts endpoint to discover how many concepts exist.
-
-    The backend paginates results; to fetch all concepts in a single
-    call we need a page size equal to the total number of concepts.
-    This helper issues a minimal ``page_size=1`` request and returns
-    ``totalElements`` from the response.
-
-    Args:
-        client: Authenticated HTTP client.
-        consents: Optional consent list for authorized deployments.
-
-    Returns:
-        Total number of concepts available to the user.  ``0`` if the
-        response omits ``totalElements``.
-    """
-    body = _build_concepts_body(term="", facets=None, consents=consents)
-    url = f"{_CONCEPTS_PATH}?page_number=0&page_size=1"
-
-    try:
-        data = client.post_json(url, body=body)
-    except (TransportValidationError, TransportNotFoundError) as exc:
-        raise _translate_dictionary_4xx(exc, "initialize the data dictionary") from exc
-    except TransportRateLimitError as exc:
-        raise PicSureConnectionError(rate_limit_message(exc)) from exc
-    except TransportError as exc:
-        raise PicSureConnectionError(
-            "Could not initialize the data dictionary. "
-            "The server may be temporarily unavailable."
-        ) from exc
-
-    total = data.get("totalElements", 0)
-    try:
-        return int(total)
-    except (TypeError, ValueError):
-        return 0
-
-
 def searchDictionary(  # noqa: N802
     client: PicSureClient,
     term: str = "",
@@ -132,15 +96,14 @@ def searchDictionary(  # noqa: N802
         include_values: If False, omit the values column.
         consents: Optional consent list.  Passed through in the body
             for authorized deployments; omitted when ``None`` or empty.
-        page_size: Page size for the request.  Should be the total
-            number of concepts (from :func:`fetch_total_concepts`) so
-            the entire result set comes back in one page.  If omitted
-            or non-positive, defaults to ``100``.
+        page_size: Page size for the request.  If omitted or
+            non-positive, defaults to :data:`_MAX_PAGE_SIZE` so the
+            entire result set comes back in one page.
 
     Returns:
         DataFrame of matching dictionary entries.
     """
-    effective_page_size = page_size if page_size and page_size > 0 else 100
+    effective_page_size = page_size if page_size and page_size > 0 else _MAX_PAGE_SIZE
     body = _build_concepts_body(term=term, facets=facets, consents=consents)
     url = f"{_CONCEPTS_PATH}?page_number=0&page_size={effective_page_size}"
 

--- a/tests/unit/dev/test_session_dev.py
+++ b/tests/unit/dev/test_session_dev.py
@@ -22,7 +22,6 @@ def _make_session(dev_enabled: bool) -> Session:
         resources=[Resource(uuid=RESOURCE_UUID, name="hpds", description="")],
         resource_uuid=RESOURCE_UUID,
         consents=[],
-        total_concepts=100,
         dev_config=cfg,
     )
 

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -16,110 +16,93 @@ from picsure.errors import (
 )
 
 
+def _b64(payload: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+
+
 def _make_jwt(exp: int | float | None) -> str:
     """Build an unsigned JWT with the given exp claim (epoch seconds)."""
-
-    def _b64(payload: dict) -> str:
-        return (
-            base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
-        )
-
-    header = _b64({"alg": "none", "typ": "JWT"})
     body: dict = {"sub": "test-user"}
     if exp is not None:
         body["exp"] = exp
-    return f"{header}.{_b64(body)}.sig"
+    return _make_jwt_claims(**body)
+
+
+def _make_jwt_claims(**claims: object) -> str:
+    """Build an unsigned JWT carrying the given payload claims."""
+    header = _b64({"alg": "none", "typ": "JWT"})
+    return f"{header}.{_b64(dict(claims))}.sig"
 
 
 BASE_URL = "https://test.example.com"
 # 2026-06-15T00:00:00Z = 1781568000 epoch seconds.
 _JWT_EXP = int(datetime(2026, 6, 15, tzinfo=timezone.utc).timestamp())
-TOKEN = _make_jwt(_JWT_EXP)
-
-
-def _concepts_prefetch_url(host: str = BASE_URL) -> str:
-    return f"{host}/picsure/proxy/dictionary-api/concepts?page_number=0&page_size=1"
-
-
-def _mock_concepts_prefetch(host: str = BASE_URL, total: int = 57) -> None:
-    respx.post(_concepts_prefetch_url(host)).mock(
-        return_value=httpx.Response(200, json={"content": [], "totalElements": total})
-    )
+# The connect banner now reads the email straight from the token, so the
+# default test token carries the email that the tests assert on.
+TOKEN = _make_jwt_claims(
+    sub="test-user", email="researcher@university.edu", exp=_JWT_EXP
+)
 
 
 def _mock_connect_flow(
-    profile_response: dict,
     resources_response: dict,
     host: str = BASE_URL,
-    total: int = 57,
 ) -> None:
-    respx.get(f"{host}/psama/user/me").mock(
-        return_value=httpx.Response(200, json=profile_response)
-    )
     respx.get(f"{host}/picsure/info/resources").mock(
         return_value=httpx.Response(200, json=resources_response)
     )
-    _mock_concepts_prefetch(host, total=total)
 
 
 class TestConnectSuccess:
     @respx.mock
-    def test_returns_session(self, profile_response, resources_response):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_returns_session(self, resources_response):
+        _mock_connect_flow(resources_response)
         session = connect(platform=BASE_URL, token=TOKEN)
         assert isinstance(session, Session)
 
     @respx.mock
-    def test_session_has_correct_email(self, profile_response, resources_response):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_session_has_correct_email(self, resources_response):
+        _mock_connect_flow(resources_response)
         session = connect(platform=BASE_URL, token=TOKEN)
         assert session._user_email == "researcher@university.edu"
 
     @respx.mock
-    def test_session_has_resources(self, profile_response, resources_response):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_session_has_resources(self, resources_response):
+        _mock_connect_flow(resources_response)
         session = connect(platform=BASE_URL, token=TOKEN)
         assert len(session._resources) == 2
         uuids = {r.uuid for r in session._resources}
         assert "resource-uuid-aaaa-1111" in uuids
 
     @respx.mock
-    def test_custom_url_has_no_resource_uuid(
-        self, profile_response, resources_response
-    ):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_custom_url_has_no_resource_uuid(self, resources_response):
+        _mock_connect_flow(resources_response)
         session = connect(platform=BASE_URL, token=TOKEN)
         assert session._resource_uuid is None
 
     @respx.mock
-    def test_prints_success_message(self, profile_response, resources_response, capsys):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_prints_success_message(self, resources_response, capsys):
+        _mock_connect_flow(resources_response)
         connect(platform=BASE_URL, token=TOKEN)
         captured = capsys.readouterr()
         assert "successfully connected" in captured.out.lower()
         assert "researcher@university.edu" in captured.out
 
     @respx.mock
-    def test_prints_token_expiration(
-        self, profile_response, resources_response, capsys
-    ):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_prints_token_expiration(self, resources_response, capsys):
+        _mock_connect_flow(resources_response)
         connect(platform=BASE_URL, token=TOKEN)
         captured = capsys.readouterr()
         assert "token expires" in captured.out.lower()
         assert "2026-06-15" in captured.out
 
-    @respx.mock
-    def test_session_stores_total_concepts(self, profile_response, resources_response):
-        _mock_connect_flow(profile_response, resources_response, total=487375)
-        session = connect(platform=BASE_URL, token=TOKEN)
-        assert session.total_concepts == 487375
-
 
 class TestConnectAuthErrors:
     @respx.mock
     def test_401_raises_auth_error(self):
-        respx.get(f"{BASE_URL}/psama/user/me").mock(
+        # /info/resources is now the first authenticated call, so it owns
+        # the friendly bad-token message the profile call used to surface.
+        respx.get(f"{BASE_URL}/picsure/info/resources").mock(
             return_value=httpx.Response(401, text="Unauthorized")
         )
 
@@ -134,7 +117,7 @@ class TestConnectAuthErrors:
 class TestConnectConnectionErrors:
     @respx.mock
     def test_network_error_raises_connection_error(self):
-        respx.get(f"{BASE_URL}/psama/user/me").mock(
+        respx.get(f"{BASE_URL}/picsure/info/resources").mock(
             side_effect=httpx.ConnectError("Connection refused")
         )
 
@@ -142,13 +125,10 @@ class TestConnectConnectionErrors:
             connect(platform=BASE_URL, token=TOKEN)
 
         msg = str(exc_info.value)
-        assert BASE_URL in msg
+        assert "resources" in msg.lower()
 
     @respx.mock
-    def test_resource_fetch_failure_raises_connection_error(self, profile_response):
-        respx.get(f"{BASE_URL}/psama/user/me").mock(
-            return_value=httpx.Response(200, json=profile_response)
-        )
+    def test_resource_fetch_failure_raises_connection_error(self):
         respx.get(f"{BASE_URL}/picsure/info/resources").mock(
             return_value=httpx.Response(500, text="Internal Server Error")
         )
@@ -160,10 +140,7 @@ class TestConnectConnectionErrors:
         assert "resources" in msg.lower()
 
     @respx.mock
-    def test_null_resources_payload_raises_connection_error(self, profile_response):
-        respx.get(f"{BASE_URL}/psama/user/me").mock(
-            return_value=httpx.Response(200, json=profile_response)
-        )
+    def test_null_resources_payload_raises_connection_error(self):
         respx.get(f"{BASE_URL}/picsure/info/resources").mock(
             return_value=httpx.Response(
                 200, content=b"null", headers={"content-type": "application/json"}
@@ -173,50 +150,27 @@ class TestConnectConnectionErrors:
         with pytest.raises(PicSureConnectionError, match="unexpected resources"):
             connect(platform=BASE_URL, token=TOKEN)
 
-    @respx.mock
-    def test_concepts_prefetch_failure_raises_connection_error(
-        self, profile_response, resources_response
-    ):
-        respx.get(f"{BASE_URL}/psama/user/me").mock(
-            return_value=httpx.Response(200, json=profile_response)
-        )
-        respx.get(f"{BASE_URL}/picsure/info/resources").mock(
-            return_value=httpx.Response(200, json=resources_response)
-        )
-        respx.post(_concepts_prefetch_url()).mock(
-            return_value=httpx.Response(500, text="Internal Server Error")
-        )
-
-        with pytest.raises(PicSureConnectionError, match="dictionary"):
-            connect(platform=BASE_URL, token=TOKEN)
-
 
 class TestConnectResourceUuid:
     @respx.mock
-    def test_explicit_uuid_overrides_platform(
-        self, profile_response, resources_response
-    ):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_explicit_uuid_overrides_platform(self, resources_response):
+        _mock_connect_flow(resources_response)
         session = connect(
             platform=BASE_URL, token=TOKEN, resource_uuid="my-custom-uuid"
         )
         assert session._resource_uuid == "my-custom-uuid"
 
     @respx.mock
-    def test_custom_url_no_uuid_prints_resources(
-        self, profile_response, resources_response, capsys
-    ):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_custom_url_no_uuid_prints_resources(self, resources_response, capsys):
+        _mock_connect_flow(resources_response)
         connect(platform=BASE_URL, token=TOKEN)
         captured = capsys.readouterr()
         assert "Available resources" in captured.out
         assert "setResourceID" in captured.out
 
     @respx.mock
-    def test_custom_url_with_uuid_no_prompt(
-        self, profile_response, resources_response, capsys
-    ):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_custom_url_with_uuid_no_prompt(self, resources_response, capsys):
+        _mock_connect_flow(resources_response)
         connect(platform=BASE_URL, token=TOKEN, resource_uuid="resource-uuid-aaaa-1111")
         captured = capsys.readouterr()
         assert "Available resources" not in captured.out
@@ -234,41 +188,6 @@ class TestConnectValidation:
             connect(platform=Platform.BDC_AUTHORIZED, token="")
 
 
-class TestConnect4xxMapping:
-    @respx.mock
-    def test_404_profile_raises_query_error(self):
-        from picsure.errors import PicSureQueryError
-
-        respx.get(f"{BASE_URL}/psama/user/me").mock(
-            return_value=httpx.Response(404, text="Not Found")
-        )
-        with pytest.raises(PicSureQueryError):
-            connect(platform=BASE_URL, token=TOKEN)
-
-    @respx.mock
-    def test_400_profile_raises_validation_error(self):
-        respx.get(f"{BASE_URL}/psama/user/me").mock(
-            return_value=httpx.Response(400, text="Bad request body")
-        )
-        with pytest.raises(PicSureValidationError) as exc_info:
-            connect(platform=BASE_URL, token=TOKEN)
-        msg = str(exc_info.value)
-        assert "400" in msg
-
-    @respx.mock
-    def test_429_profile_raises_connection_error_with_retry_after(self):
-        respx.get(f"{BASE_URL}/psama/user/me").mock(
-            return_value=httpx.Response(
-                429, text="slow down", headers={"Retry-After": "45"}
-            )
-        )
-        with pytest.raises(PicSureConnectionError) as exc_info:
-            connect(platform=BASE_URL, token=TOKEN)
-        msg = str(exc_info.value)
-        assert "45" in msg
-        assert "retry" in msg.lower()
-
-
 class TestConnectConsents:
     _TEMPLATE_URL = f"{BASE_URL}/psama/user/me/queryTemplate/"
     _CONSENT_PAYLOAD = {
@@ -278,10 +197,8 @@ class TestConnectConsents:
     }
 
     @respx.mock
-    def test_custom_url_skips_consent_fetch_by_default(
-        self, profile_response, resources_response
-    ):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_custom_url_skips_consent_fetch_by_default(self, resources_response):
+        _mock_connect_flow(resources_response)
         template_route = respx.get(self._TEMPLATE_URL).mock(
             return_value=httpx.Response(200, json=self._CONSENT_PAYLOAD)
         )
@@ -292,10 +209,8 @@ class TestConnectConsents:
         assert session.consents == []
 
     @respx.mock
-    def test_include_consents_kwarg_fetches_consents(
-        self, profile_response, resources_response
-    ):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_include_consents_kwarg_fetches_consents(self, resources_response):
+        _mock_connect_flow(resources_response)
         respx.get(self._TEMPLATE_URL).mock(
             return_value=httpx.Response(200, json=self._CONSENT_PAYLOAD)
         )
@@ -305,35 +220,11 @@ class TestConnectConsents:
         assert session.consents == ["phs000007.c1", "phs001013.c1"]
 
     @respx.mock
-    def test_consents_forwarded_to_prefetch(self, profile_response, resources_response):
-        respx.get(f"{BASE_URL}/psama/user/me").mock(
-            return_value=httpx.Response(200, json=profile_response)
-        )
-        respx.get(f"{BASE_URL}/picsure/info/resources").mock(
-            return_value=httpx.Response(200, json=resources_response)
-        )
-        respx.get(self._TEMPLATE_URL).mock(
-            return_value=httpx.Response(200, json=self._CONSENT_PAYLOAD)
-        )
-        prefetch_route = respx.post(_concepts_prefetch_url()).mock(
-            return_value=httpx.Response(200, json={"content": [], "totalElements": 100})
-        )
-
-        connect(platform=BASE_URL, token=TOKEN, include_consents=True)
-
-        import json
-
-        body = json.loads(prefetch_route.calls[0].request.content)
-        assert body["consents"] == ["phs000007.c1", "phs001013.c1"]
-
-    @respx.mock
-    def test_include_consents_false_override_skips_fetch(
-        self, profile_response, resources_response
-    ):
+    def test_include_consents_false_override_skips_fetch(self, resources_response):
         from picsure._transport.platforms import Platform
 
         prod_url = Platform.BDC_AUTHORIZED.url
-        _mock_connect_flow(profile_response, resources_response, host=prod_url)
+        _mock_connect_flow(resources_response, host=prod_url)
         template_route = respx.get(f"{prod_url}/psama/user/me/queryTemplate/").mock(
             return_value=httpx.Response(200, json=self._CONSENT_PAYLOAD)
         )
@@ -348,21 +239,16 @@ class TestConnectConsents:
 
 class TestConnectOpenAccess:
     @respx.mock
-    def test_open_platform_skips_profile_fetch(self, resources_response):
+    def test_open_platform_connects_anonymously(self, resources_response):
         from picsure._transport.platforms import Platform
 
         host = Platform.BDC_DEV_OPEN.url
-        profile_route = respx.get(f"{host}/psama/user/me").mock(
-            return_value=httpx.Response(401)
-        )
         respx.get(f"{host}/picsure/info/resources").mock(
             return_value=httpx.Response(200, json=resources_response)
         )
-        _mock_concepts_prefetch(host=host, total=100)
 
         session = connect(platform=Platform.BDC_DEV_OPEN)
 
-        assert profile_route.called is False
         assert session._user_email == "anonymous"
         assert session._token_expiration == "N/A"
         assert session.consents == []
@@ -378,7 +264,6 @@ class TestConnectOpenAccess:
         template_route = respx.get(f"{host}/psama/user/me/queryTemplate/").mock(
             return_value=httpx.Response(200, json={})
         )
-        _mock_concepts_prefetch(host=host, total=100)
 
         connect(platform=Platform.BDC_DEV_OPEN)
 
@@ -392,7 +277,6 @@ class TestConnectOpenAccess:
         respx.get(f"{host}/picsure/info/resources").mock(
             return_value=httpx.Response(401)
         )
-        _mock_concepts_prefetch(host=host, total=100)
 
         session = connect(platform=Platform.BDC_DEV_OPEN)
 
@@ -406,14 +290,10 @@ class TestConnectOpenAccess:
         resources_route = respx.get(f"{host}/picsure/info/resources").mock(
             return_value=httpx.Response(200, json=resources_response)
         )
-        prefetch_route = respx.post(_concepts_prefetch_url(host)).mock(
-            return_value=httpx.Response(200, json={"content": [], "totalElements": 0})
-        )
 
         connect(platform=Platform.BDC_DEV_OPEN)
 
         assert "authorization" not in resources_route.calls[0].request.headers
-        assert "authorization" not in prefetch_route.calls[0].request.headers
 
     @respx.mock
     def test_open_platform_success_message(self, resources_response, capsys):
@@ -423,7 +303,6 @@ class TestConnectOpenAccess:
         respx.get(f"{host}/picsure/info/resources").mock(
             return_value=httpx.Response(200, json=resources_response)
         )
-        _mock_concepts_prefetch(host=host, total=100)
 
         connect(platform=Platform.BDC_DEV_OPEN)
 
@@ -436,7 +315,6 @@ class TestConnectOpenAccess:
         respx.get(f"{BASE_URL}/picsure/info/resources").mock(
             return_value=httpx.Response(200, json=resources_response)
         )
-        _mock_concepts_prefetch(host=BASE_URL, total=10)
 
         session = connect(platform=BASE_URL, requires_auth=False)
 
@@ -455,20 +333,17 @@ class TestConnectLegacyQueryPath:
         respx.get(f"{host}/picsure/info/resources").mock(
             return_value=httpx.Response(200, json=resources_response)
         )
-        _mock_concepts_prefetch(host=host, total=100)
 
         session = connect(platform=Platform.BDC_DEV_OPEN)
 
         assert session._use_legacy_query_path is True
 
     @respx.mock
-    def test_authorized_platform_uses_v3_query_path(
-        self, profile_response, resources_response
-    ):
+    def test_authorized_platform_uses_v3_query_path(self, resources_response):
         from picsure._transport.platforms import Platform
 
         host = Platform.BDC_DEV_AUTHORIZED.url
-        _mock_connect_flow(profile_response, resources_response, host=host)
+        _mock_connect_flow(resources_response, host=host)
         respx.get(f"{host}/psama/user/me/queryTemplate/").mock(
             return_value=httpx.Response(200, json={})
         )
@@ -479,12 +354,10 @@ class TestConnectLegacyQueryPath:
         assert session._use_legacy_query_path is False
 
     @respx.mock
-    def test_custom_url_default_uses_v3_query_path(
-        self, profile_response, resources_response
-    ):
+    def test_custom_url_default_uses_v3_query_path(self, resources_response):
         # Custom URLs default to requires_auth=True, so legacy routing
         # stays off.
-        _mock_connect_flow(profile_response, resources_response)
+        _mock_connect_flow(resources_response)
 
         session = connect(platform=BASE_URL, token=TOKEN)
 
@@ -496,19 +369,16 @@ class TestConnectLegacyQueryPath:
         respx.get(f"{BASE_URL}/picsure/info/resources").mock(
             return_value=httpx.Response(200, json=resources_response)
         )
-        _mock_concepts_prefetch(host=BASE_URL, total=10)
 
         session = connect(platform=BASE_URL, requires_auth=False)
 
         assert session._use_legacy_query_path is True
 
     @respx.mock
-    def test_consents_only_keeps_v3_query_path(
-        self, profile_response, resources_response
-    ):
+    def test_consents_only_keeps_v3_query_path(self, resources_response):
         # If the deployment requires consents (even with auth on), it's
         # an authorized backend — stay on v3.
-        _mock_connect_flow(profile_response, resources_response)
+        _mock_connect_flow(resources_response)
         respx.get(f"{BASE_URL}/psama/user/me/queryTemplate/").mock(
             return_value=httpx.Response(200, json={})
         )
@@ -524,18 +394,14 @@ class TestConnectLegacyQueryPath:
 
 class TestConnectSupportsGenomic:
     @respx.mock
-    def test_connect_threads_supports_genomic_override(
-        self, profile_response, resources_response
-    ):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_connect_threads_supports_genomic_override(self, resources_response):
+        _mock_connect_flow(resources_response)
         session = connect(platform=BASE_URL, token=TOKEN, supports_genomic=True)
         assert session._supports_genomic is True
 
     @respx.mock
-    def test_connect_supports_genomic_defaults_false(
-        self, profile_response, resources_response
-    ):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_connect_supports_genomic_defaults_false(self, resources_response):
+        _mock_connect_flow(resources_response)
         session = connect(platform=BASE_URL, token=TOKEN)
         assert session._supports_genomic is False
 
@@ -558,28 +424,61 @@ class TestTokenExpirationFromJwt:
         assert _token_expiration_from_jwt(_make_jwt("tomorrow")) == "unknown"  # type: ignore[arg-type]
 
 
+class TestEmailFromJwt:
+    def test_reads_email_claim(self):
+        from picsure._services.connect import _email_from_jwt
+
+        token = _make_jwt_claims(email="user@example.com", sub="abc")
+        assert _email_from_jwt(token) == "user@example.com"
+
+    def test_falls_back_to_preferred_username(self):
+        from picsure._services.connect import _email_from_jwt
+
+        token = _make_jwt_claims(preferred_username="jdoe@idp", sub="abc")
+        assert _email_from_jwt(token) == "jdoe@idp"
+
+    def test_falls_back_to_sub(self):
+        from picsure._services.connect import _email_from_jwt
+
+        token = _make_jwt_claims(sub="subject-123")
+        assert _email_from_jwt(token) == "subject-123"
+
+    def test_empty_email_skips_to_next_claim(self):
+        from picsure._services.connect import _email_from_jwt
+
+        token = _make_jwt_claims(email="   ", preferred_username="jdoe@idp")
+        assert _email_from_jwt(token) == "jdoe@idp"
+
+    def test_no_usable_claim_returns_unknown(self):
+        from picsure._services.connect import _email_from_jwt
+
+        token = _make_jwt_claims(name="First Last")
+        assert _email_from_jwt(token) == "unknown"
+
+    def test_non_jwt_returns_unknown(self):
+        from picsure._services.connect import _email_from_jwt
+
+        assert _email_from_jwt("not-a-jwt") == "unknown"
+
+
 class TestConnectCorrelationHeaders:
     @respx.mock
-    def test_connect_sends_session_id_and_default_client_type(
-        self, profile_response, resources_response
-    ):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_connect_sends_session_id_and_default_client_type(self, resources_response):
+        _mock_connect_flow(resources_response)
         session = connect(platform=BASE_URL, token=TOKEN)
 
         # session.session_id is a freshly generated uuid4 string.
         assert uuid.UUID(session.session_id)
 
         # Every request in the flow carries the correlation headers.
-        profile_req = respx.calls[0].request
-        assert profile_req.headers["x-session-id"] == session.session_id
-        assert profile_req.headers["x-client-type"] == "PYTHON_ADAPTER"
-        assert profile_req.headers["user-agent"].startswith("picsure-python-adapter/")
+        first_req = respx.calls[0].request
+        assert first_req.headers["x-session-id"] == session.session_id
+        assert first_req.headers["x-client-type"] == "PYTHON_ADAPTER"
+        assert first_req.headers["user-agent"].startswith("picsure-python-adapter/")
 
     @respx.mock
-    def test_connect_forwards_client_type_override(
-        self, profile_response, resources_response
-    ):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_connect_forwards_client_type_override(self, resources_response):
+        _mock_connect_flow(resources_response)
         session = connect(platform=BASE_URL, token=TOKEN, client_type="R_ADAPTER")
 
         assert respx.calls[0].request.headers["x-client-type"] == "R_ADAPTER"
@@ -592,10 +491,8 @@ class TestConnectCorrelationHeaders:
         assert uuid.UUID(session.session_id)
 
     @respx.mock
-    def test_each_connect_gets_a_distinct_session_id(
-        self, profile_response, resources_response
-    ):
-        _mock_connect_flow(profile_response, resources_response)
+    def test_each_connect_gets_a_distinct_session_id(self, resources_response):
+        _mock_connect_flow(resources_response)
         first = connect(platform=BASE_URL, token=TOKEN)
         second = connect(platform=BASE_URL, token=TOKEN)
         assert first.session_id != second.session_id

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -6,8 +6,8 @@ import respx
 
 from picsure._models.facet import FacetCategory, FacetSet
 from picsure._services.search import (
+    _MAX_PAGE_SIZE,
     fetch_facets,
-    fetch_total_concepts,
     searchDictionary,
     show_all_facets,
 )
@@ -31,7 +31,7 @@ def _concepts_url(page_size: int) -> str:
 class TestSearch:
     @respx.mock
     def test_returns_dataframe(self, search_response):
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=search_response)
         )
         df = searchDictionary(_make_client(), term="sex")
@@ -41,7 +41,7 @@ class TestSearch:
 
     @respx.mock
     def test_dataframe_has_correct_columns(self, search_response):
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=search_response)
         )
         df = searchDictionary(_make_client(), term="sex")
@@ -64,7 +64,7 @@ class TestSearch:
     def test_continuous_fields_populated(self, search_response):
         import pandas as pd
 
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=search_response)
         )
         df = searchDictionary(_make_client(), term="age")
@@ -79,7 +79,7 @@ class TestSearch:
 
     @respx.mock
     def test_include_values_false_still_has_extra_columns(self, search_response):
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=search_response)
         )
         df = searchDictionary(_make_client(), term="sex", include_values=False)
@@ -88,7 +88,7 @@ class TestSearch:
 
     @respx.mock
     def test_maps_dataset_and_type_fields(self, search_response):
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=search_response)
         )
         df = searchDictionary(_make_client(), term="sex")
@@ -98,7 +98,7 @@ class TestSearch:
 
     @respx.mock
     def test_body_shape(self, search_response):
-        route = respx.post(_concepts_url(100)).mock(
+        route = respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=search_response)
         )
         searchDictionary(_make_client(), term="blood pressure")
@@ -107,7 +107,7 @@ class TestSearch:
 
     @respx.mock
     def test_sends_facets_in_body(self, search_response):
-        route = respx.post(_concepts_url(100)).mock(
+        route = respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=search_response)
         )
         from picsure._models.facet import Facet
@@ -152,7 +152,7 @@ class TestSearch:
 
     @respx.mock
     def test_consents_included_when_provided(self, search_response):
-        route = respx.post(_concepts_url(100)).mock(
+        route = respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=search_response)
         )
         searchDictionary(
@@ -165,7 +165,7 @@ class TestSearch:
 
     @respx.mock
     def test_consents_omitted_when_empty(self, search_response):
-        route = respx.post(_concepts_url(100)).mock(
+        route = respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=search_response)
         )
         searchDictionary(_make_client(), term="age", consents=[])
@@ -174,12 +174,21 @@ class TestSearch:
 
     @respx.mock
     def test_consents_omitted_when_none(self, search_response):
-        route = respx.post(_concepts_url(100)).mock(
+        route = respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=search_response)
         )
         searchDictionary(_make_client(), term="age")
         body = json.loads(route.calls[0].request.content)
         assert "consents" not in body
+
+    @respx.mock
+    def test_default_page_size_is_max_int(self, search_response):
+        assert _MAX_PAGE_SIZE == 2_147_483_647
+        route = respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
+            return_value=httpx.Response(200, json=search_response)
+        )
+        searchDictionary(_make_client(), term="age")
+        assert route.called
 
     @respx.mock
     def test_page_size_used_in_url(self, search_response):
@@ -191,7 +200,7 @@ class TestSearch:
 
     @respx.mock
     def test_non_positive_page_size_falls_back_to_default(self, search_response):
-        route = respx.post(_concepts_url(100)).mock(
+        route = respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=search_response)
         )
         searchDictionary(_make_client(), term="age", page_size=0)
@@ -208,7 +217,7 @@ class TestSearch:
             "totalElements": 3,
             "last": True,
         }
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=duplicate_response)
         )
         df = searchDictionary(_make_client())
@@ -217,7 +226,7 @@ class TestSearch:
 
     @respx.mock
     def test_zero_results_returns_empty_dataframe(self):
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(
                 200, json={"content": [], "totalElements": 0, "last": True}
             )
@@ -228,7 +237,7 @@ class TestSearch:
 
     @respx.mock
     def test_zero_results_prints_note(self, capsys):
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(
                 200, json={"content": [], "totalElements": 0, "last": True}
             )
@@ -247,7 +256,7 @@ class TestSearch:
             "totalElements": 5,
             "last": False,
         }
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=truncated)
         )
         with pytest.raises(PicSureQueryError, match="truncated"):
@@ -261,7 +270,7 @@ class TestSearch:
             "content": [{"conceptPath": "\\x\\", "name": "x"}],
             "totalElements": 1,
         }
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=response)
         )
         df = searchDictionary(_make_client(), term="x")
@@ -276,7 +285,7 @@ class TestSearch:
             "totalElements": 3,
             "last": True,
         }
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(200, json=response)
         )
         with pytest.raises(PicSureQueryError, match="truncated"):
@@ -284,7 +293,7 @@ class TestSearch:
 
     @respx.mock
     def test_server_error_raises_connection_error(self):
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             return_value=httpx.Response(500, text="Internal Server Error")
         )
         with pytest.raises(PicSureConnectionError, match="search"):
@@ -292,53 +301,11 @@ class TestSearch:
 
     @respx.mock
     def test_network_error_raises_connection_error(self):
-        respx.post(_concepts_url(100)).mock(
+        respx.post(_concepts_url(_MAX_PAGE_SIZE)).mock(
             side_effect=httpx.ConnectError("Connection refused")
         )
         with pytest.raises(PicSureConnectionError):
             searchDictionary(_make_client(), term="test")
-
-
-class TestFetchTotalConcepts:
-    @respx.mock
-    def test_returns_total_elements(self):
-        respx.post(_concepts_url(1)).mock(
-            return_value=httpx.Response(
-                200, json={"content": [], "totalElements": 487375}
-            )
-        )
-        assert fetch_total_concepts(_make_client()) == 487375
-
-    @respx.mock
-    def test_body_shape(self):
-        route = respx.post(_concepts_url(1)).mock(
-            return_value=httpx.Response(200, json={"totalElements": 0})
-        )
-        fetch_total_concepts(_make_client())
-        body = json.loads(route.calls[0].request.content)
-        assert body == {"search": "", "facets": []}
-
-    @respx.mock
-    def test_consents_forwarded(self):
-        route = respx.post(_concepts_url(1)).mock(
-            return_value=httpx.Response(200, json={"totalElements": 0})
-        )
-        fetch_total_concepts(_make_client(), consents=["phs000007.c1"])
-        body = json.loads(route.calls[0].request.content)
-        assert body["consents"] == ["phs000007.c1"]
-
-    @respx.mock
-    def test_missing_total_returns_zero(self):
-        respx.post(_concepts_url(1)).mock(
-            return_value=httpx.Response(200, json={"content": []})
-        )
-        assert fetch_total_concepts(_make_client()) == 0
-
-    @respx.mock
-    def test_server_error_raises_connection_error(self):
-        respx.post(_concepts_url(1)).mock(return_value=httpx.Response(500))
-        with pytest.raises(PicSureConnectionError, match="dictionary"):
-            fetch_total_concepts(_make_client())
 
 
 class TestFetchFacets:

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -312,7 +312,8 @@ def _metadata_envelope(
 
 
 _CONCEPTS_URL = (
-    f"{BASE_URL}/picsure/proxy/dictionary-api/concepts?page_number=0&page_size=100"
+    f"{BASE_URL}/picsure/proxy/dictionary-api/concepts"
+    "?page_number=0&page_size=2147483647"
 )
 _FACETS_URL = f"{BASE_URL}/picsure/proxy/dictionary-api/facets"
 


### PR DESCRIPTION
…` logic

- Replace `/psama/user/me` with JWT claims for email and token expiration.
- Remove `fetch_total_concepts` and prefetch logic for dictionary API queries; support single-query max page size.
- Simplify `connect()` by dropping unused profile-related logic and unused metadata fields.
- Update documentation and tests to reflect changes.