### PR TITLE
fix(transport): recover from stale connections; harden retry/mapping across httpx failure modes

### DIFF
--- a/src/picsure/_transport/client.py
+++ b/src/picsure/_transport/client.py
@@ -148,6 +148,17 @@ class PicSureClient:
                 if attempt < _MAX_RETRIES:
                     continue
                 raise TransportConnectionError(str(exc)) from exc
+            except httpx.RemoteProtocolError as exc:
+                last_exc = exc
+                # Stale pooled connection: the server closed it before sending
+                # any response, so the request was never processed.  Safe to
+                # retry once on a fresh connection, even for this POST.
+                if attempt < _MAX_RETRIES:
+                    continue
+                raise TransportConnectionError(
+                    f"Server closed the connection before responding "
+                    f"(stale pooled connection): {exc}"
+                ) from exc
             except httpx.TimeoutException as exc:
                 last_exc = exc
                 if attempt < _MAX_RETRIES:
@@ -195,6 +206,22 @@ class PicSureClient:
                 if attempt < _MAX_RETRIES:
                     continue
                 raise _mark_emitted(TransportConnectionError(str(exc))) from exc
+            except httpx.RemoteProtocolError as exc:
+                last_exc = exc
+                self._emit_error(method, path, attempt, start, type(exc).__name__)
+                # The server closed a pooled keep-alive connection before
+                # sending any response (the classic stale-connection symptom in
+                # a long-lived session).  Because no response was produced, the
+                # request was never processed, so retrying once on a fresh
+                # connection is safe for every method -- including POST.
+                if attempt < _MAX_RETRIES:
+                    continue
+                raise _mark_emitted(
+                    TransportConnectionError(
+                        f"Server closed the connection before responding "
+                        f"(stale pooled connection): {exc}"
+                    )
+                ) from exc
             except httpx.TimeoutException as exc:
                 last_exc = exc
                 self._emit_error(method, path, attempt, start, type(exc).__name__)

--- a/src/picsure/_transport/client.py
+++ b/src/picsure/_transport/client.py
@@ -26,6 +26,84 @@ if TYPE_CHECKING:
 _MAX_RETRIES = 1
 _TIMEOUT_SECONDS = 30.0
 
+# Transport failures where the request provably never reached the server --
+# or never finished being sent -- so re-sending cannot double-execute even a
+# non-idempotent POST:
+#   - ConnectError / ConnectTimeout: no connection was ever established.
+#   - PoolTimeout: the request never left the local connection pool.
+#   - WriteError: sending the request failed part-way (e.g. EPIPE on a stale
+#     pooled connection the server killed with RST); the server cannot
+#     process a request it never fully received.
+_PRE_SEND_FAILURES = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.PoolTimeout,
+    httpx.WriteError,
+)
+
+# Deterministic configuration or client-side errors where a retry cannot
+# change the outcome: a proxy refusing the connection, a base URL whose
+# scheme httpx does not support, a request httpx itself considers malformed.
+_NO_RETRY_FAILURES = (
+    httpx.ProxyError,
+    httpx.UnsupportedProtocol,
+    httpx.LocalProtocolError,
+)
+
+
+def _server_disconnected_before_response(exc: httpx.RemoteProtocolError) -> bool:
+    """True for the stale pooled keep-alive symptom.
+
+    httpcore uses this exact wording only when the server closed the
+    connection before sending any part of a response -- meaning the request
+    was never processed.  Every other ``RemoteProtocolError`` (truncated
+    body, malformed response) arrives *after* the server received -- and may
+    have executed -- the request, so it must not be blindly re-sent for
+    non-GETs.  If a future httpcore rewords the message this degrades
+    safely: non-GETs simply stop retrying this case.
+    """
+    return str(exc).startswith("Server disconnected")
+
+
+def _should_retry(method: str, exc: httpx.TransportError) -> bool:
+    """Whether a failed request is safe to send again.
+
+    Safe for every method when the request provably never reached the
+    server; otherwise only for idempotent GETs (the server may already
+    have processed the request).
+    """
+    if isinstance(exc, _NO_RETRY_FAILURES):
+        return False
+    if isinstance(exc, _PRE_SEND_FAILURES):
+        return True
+    if isinstance(
+        exc, httpx.RemoteProtocolError
+    ) and _server_disconnected_before_response(exc):
+        return True
+    # ReadError, ReadTimeout, WriteTimeout, CloseError, truncated-body
+    # RemoteProtocolError, ...: the request was fully sent and the failure
+    # happened while receiving the response.
+    return method == "GET"
+
+
+def _connection_failure_message(exc: httpx.TransportError) -> str:
+    """Build the ``TransportConnectionError`` message for a failure."""
+    if isinstance(
+        exc, httpx.RemoteProtocolError
+    ) and _server_disconnected_before_response(exc):
+        return (
+            "Server closed the connection before responding "
+            f"(stale pooled connection): {exc}"
+        )
+    if isinstance(exc, httpx.TimeoutException):
+        return f"Request timed out: {exc}"
+    if isinstance(exc, (httpx.ReadError, httpx.WriteError, httpx.CloseError)):
+        return (
+            "Network error on an established connection (possibly a stale "
+            f"pooled connection closed by the server): {exc}"
+        )
+    return str(exc) or type(exc).__name__
+
 
 def _package_version() -> str:
     """Return the installed ``picsure`` version, or ``"unknown"``."""
@@ -135,7 +213,10 @@ class PicSureClient:
         to transport exceptions *before* the context manager yields, so
         callers don't need to re-check the status code.  The response
         body for the error mapping is read eagerly (it's small), but the
-        success-path body is left as a live stream.
+        success-path body is left as a live stream.  A transport failure
+        while the caller drains the stream is translated to
+        :class:`TransportConnectionError` as well, so no raw httpx
+        exception escapes this context manager.
         """
         last_exc: Exception | None = None
 
@@ -143,36 +224,29 @@ class PicSureClient:
             stream_cm = self._http.stream("POST", path, json=body)
             try:
                 response = stream_cm.__enter__()
-            except httpx.ConnectError as exc:
+            except httpx.TransportError as exc:
                 last_exc = exc
-                if attempt < _MAX_RETRIES:
-                    continue
-                raise TransportConnectionError(str(exc)) from exc
-            except httpx.RemoteProtocolError as exc:
-                last_exc = exc
-                # Stale pooled connection: the server closed it before sending
-                # any response, so the request was never processed.  Safe to
-                # retry once on a fresh connection, even for this POST.
-                if attempt < _MAX_RETRIES:
+                # This stream is always a POST, so retry only the failures
+                # where the request provably never reached the server (see
+                # _should_retry).
+                if _should_retry("POST", exc) and attempt < _MAX_RETRIES:
                     continue
                 raise TransportConnectionError(
-                    f"Server closed the connection before responding "
-                    f"(stale pooled connection): {exc}"
+                    _connection_failure_message(exc)
                 ) from exc
-            except httpx.TimeoutException as exc:
-                last_exc = exc
-                if attempt < _MAX_RETRIES:
-                    continue
-                raise TransportConnectionError(f"Request timed out: {exc}") from exc
 
             status = response.status_code
 
             if status >= 400:
                 # Read the (presumably small) error body so the mapper
-                # below can include a preview, then close the stream.
+                # below can include a preview, then close the stream.  The
+                # status alone drives the mapping, so degrade to a
+                # placeholder if the connection drops mid-read.
                 try:
                     response.read()
                     body_text = response.text
+                except httpx.TransportError as exc:
+                    body_text = f"<error body unavailable: {exc}>"
                 finally:
                     stream_cm.__exit__(None, None, None)
                 if 400 <= status < 500:
@@ -180,9 +254,17 @@ class PicSureClient:
                 # POST /stream is non-idempotent; do not retry on 5xx.
                 raise TransportServerError(status, body_text)
 
-            # Happy path: hand the live response to the caller.
+            # Happy path: hand the live response to the caller.  A transport
+            # failure while the caller drains the stream is thrown back into
+            # this generator at the yield; translate it so callers see the
+            # Transport* contract, never a raw httpx error.  No retry is
+            # possible here -- part of the body has already been consumed.
             try:
                 yield response
+            except httpx.TransportError as exc:
+                raise TransportConnectionError(
+                    f"Connection failed while streaming the response: {exc}"
+                ) from exc
             finally:
                 stream_cm.__exit__(None, None, None)
             return
@@ -198,40 +280,18 @@ class PicSureClient:
             start = time.monotonic()
             try:
                 response = self._http.request(method, path, **kwargs)  # type: ignore[arg-type]
-            except httpx.ConnectError as exc:
+            except httpx.TransportError as exc:
                 last_exc = exc
                 self._emit_error(method, path, attempt, start, type(exc).__name__)
-                # Connection errors are idempotent-safe: the request never
-                # reached the server, so retrying can't double-execute.
-                if attempt < _MAX_RETRIES:
-                    continue
-                raise _mark_emitted(TransportConnectionError(str(exc))) from exc
-            except httpx.RemoteProtocolError as exc:
-                last_exc = exc
-                self._emit_error(method, path, attempt, start, type(exc).__name__)
-                # The server closed a pooled keep-alive connection before
-                # sending any response (the classic stale-connection symptom in
-                # a long-lived session).  Because no response was produced, the
-                # request was never processed, so retrying once on a fresh
-                # connection is safe for every method -- including POST.
-                if attempt < _MAX_RETRIES:
+                # Retry only when re-sending cannot double-execute: failures
+                # where the request never reached the server retry for every
+                # method; failures after the request was fully sent (the
+                # server may have processed it) retry for GETs only.  See
+                # _should_retry for the per-exception classification.
+                if _should_retry(method, exc) and attempt < _MAX_RETRIES:
                     continue
                 raise _mark_emitted(
-                    TransportConnectionError(
-                        f"Server closed the connection before responding "
-                        f"(stale pooled connection): {exc}"
-                    )
-                ) from exc
-            except httpx.TimeoutException as exc:
-                last_exc = exc
-                self._emit_error(method, path, attempt, start, type(exc).__name__)
-                # Read-timeouts on POST may mean the server already processed
-                # the request; retrying could duplicate a non-idempotent
-                # mutation.  Only retry GETs.
-                if method == "GET" and attempt < _MAX_RETRIES:
-                    continue
-                raise _mark_emitted(
-                    TransportConnectionError(f"Request timed out: {exc}")
+                    TransportConnectionError(_connection_failure_message(exc))
                 ) from exc
 
             self._emit_http(method, path, body, response, attempt, start)

--- a/tests/unit/dev/test_client_events.py
+++ b/tests/unit/dev/test_client_events.py
@@ -69,9 +69,14 @@ def test_retry_emits_two_events():
 
 @respx.mock
 def test_stale_connection_retry_emits_error_event_then_success():
+    # Exact wording httpx/httpcore use for a stale pooled connection; the
+    # retry policy discriminates RemoteProtocolError variants on it, so the
+    # simulated failure must stay faithful to real traffic.
     respx.post(f"{BASE_URL}/query/sync").mock(
         side_effect=[
-            httpx.RemoteProtocolError("Server disconnected without responding."),
+            httpx.RemoteProtocolError(
+                "Server disconnected without sending a response."
+            ),
             httpx.Response(200, json={"ok": True}),
         ]
     )

--- a/tests/unit/dev/test_client_events.py
+++ b/tests/unit/dev/test_client_events.py
@@ -68,6 +68,29 @@ def test_retry_emits_two_events():
 
 
 @respx.mock
+def test_stale_connection_retry_emits_error_event_then_success():
+    respx.post(f"{BASE_URL}/query/sync").mock(
+        side_effect=[
+            httpx.RemoteProtocolError("Server disconnected without responding."),
+            httpx.Response(200, json={"ok": True}),
+        ]
+    )
+    cfg = DevConfig(enabled=True, max_events=10)
+    client = PicSureClient(base_url=BASE_URL, token=TOKEN, dev_config=cfg)
+
+    client.post_json("/query/sync", body={"q": "x"})
+
+    events = cfg.buffer.snapshot()
+    # The stale first attempt is recorded as an error event; the retry that
+    # succeeds on a fresh connection is recorded as an http event.
+    assert any(
+        e.kind == "error" and e.error == "RemoteProtocolError" and e.retry == 0
+        for e in events
+    )
+    assert any(e.kind == "http" and e.status == 200 and e.retry == 1 for e in events)
+
+
+@respx.mock
 def test_connection_error_emits_error_event_then_raises():
     respx.get(f"{BASE_URL}/down").mock(side_effect=httpx.ConnectError("refused"))
     cfg = DevConfig(enabled=True, max_events=10)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -15,6 +15,10 @@ from picsure._transport.errors import (
 BASE_URL = "https://test.example.com"
 TOKEN = "test-token-abc123"
 
+# The message httpx raises when a pooled keep-alive connection was closed by
+# the server before it responded -- the stale-connection symptom under test.
+STALE_CONN_MSG = "Server disconnected without sending a response."
+
 
 class TestPicSureClient:
     @respx.mock
@@ -311,6 +315,86 @@ class TestPicSureClientRetryScoping:
         # A second close should not raise.
         client.close()
         assert client._http.is_closed
+
+
+class TestPicSureClientStaleConnection:
+    """A pooled keep-alive connection the server has silently closed surfaces
+    as httpx.RemoteProtocolError ("Server disconnected without sending a
+    response"). Because the server never produced a response, it never
+    processed the request, so retrying once on a fresh connection is safe for
+    every method -- including non-idempotent POST.
+    """
+
+    @respx.mock
+    def test_post_remote_protocol_error_retries_then_succeeds(self):
+        route = respx.post(f"{BASE_URL}/query/sync").mock(
+            side_effect=[
+                httpx.RemoteProtocolError(STALE_CONN_MSG),
+                httpx.Response(200, json={"recovered": True}),
+            ]
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        result = client.post_json("/query/sync", body={"q": "x"})
+
+        assert result == {"recovered": True}
+        assert route.call_count == 2  # stale connection + retry on a fresh one
+
+    @respx.mock
+    def test_post_remote_protocol_error_exhausts_raises_connection_error(self):
+        route = respx.post(f"{BASE_URL}/query/sync").mock(
+            side_effect=httpx.RemoteProtocolError(STALE_CONN_MSG)
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        with pytest.raises(TransportConnectionError, match="stale"):
+            client.post_json("/query/sync", body={"q": "x"})
+        assert route.call_count == 2  # initial + 1 retry
+
+    @respx.mock
+    def test_get_remote_protocol_error_retries_then_succeeds(self):
+        route = respx.get(f"{BASE_URL}/flaky").mock(
+            side_effect=[
+                httpx.RemoteProtocolError(STALE_CONN_MSG),
+                httpx.Response(200, json={"ok": True}),
+            ]
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        result = client.get_json("/flaky")
+
+        assert result == {"ok": True}
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_post_raw_stream_remote_protocol_error_retries_then_succeeds(self):
+        route = respx.post(f"{BASE_URL}/export").mock(
+            side_effect=[
+                httpx.RemoteProtocolError(STALE_CONN_MSG),
+                httpx.Response(200, content=b"streamed-bytes"),
+            ]
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        with client.post_raw_stream("/export", body={"q": "x"}) as response:
+            data = b"".join(response.iter_bytes())
+
+        assert data == b"streamed-bytes"
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_post_raw_stream_remote_protocol_error_exhausts_raises(self):
+        route = respx.post(f"{BASE_URL}/export").mock(
+            side_effect=httpx.RemoteProtocolError(STALE_CONN_MSG)
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        with (
+            pytest.raises(TransportConnectionError, match="stale"),
+            client.post_raw_stream("/export", body={"q": "x"}) as response,
+        ):
+            b"".join(response.iter_bytes())
+        assert route.call_count == 2
 
 
 class TestPicSureClientCorrelationHeaders:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -19,6 +19,23 @@ TOKEN = "test-token-abc123"
 # the server before it responded -- the stale-connection symptom under test.
 STALE_CONN_MSG = "Server disconnected without sending a response."
 
+# The message httpx raises when the connection dies part-way through the
+# response body.  Same exception class as STALE_CONN_MSG, but here the server
+# received -- and may have executed -- the request, so a blind POST retry
+# would double-execute it.
+TRUNCATED_BODY_MSG = (
+    "peer closed connection without sending complete message body "
+    "(received 5 bytes, expected 100)"
+)
+
+
+class _FailsMidStream(httpx.SyncByteStream):
+    """Response stream that yields one chunk, then dies like a reset."""
+
+    def __iter__(self):
+        yield b"first-chunk"
+        raise httpx.ReadError("Connection reset by peer")
+
 
 class TestPicSureClient:
     @respx.mock
@@ -389,12 +406,186 @@ class TestPicSureClientStaleConnection:
         )
         client = PicSureClient(base_url=BASE_URL, token=TOKEN)
 
+        # Both attempts fail while opening the stream, so the failure
+        # surfaces from __enter__ -- a with-block body would be dead code.
+        stream = client.post_raw_stream("/export", body={"q": "x"})
+        with pytest.raises(TransportConnectionError, match="stale"):
+            stream.__enter__()
+        assert route.call_count == 2
+
+
+class TestPicSureClientRetrySafety:
+    """Retry/mapping policy across the httpx failure modes.
+
+    Two invariants:  (1) a request is re-sent only when it provably never
+    reached the server (or, for GETs, when re-sending is idempotent-safe);
+    (2) every httpx.TransportError surfaces as a Transport* exception --
+    never as a raw httpx error.
+    """
+
+    @respx.mock
+    def test_post_truncated_body_does_not_retry(self):
+        # Same exception class as the stale-connection case, but the server
+        # already received (and may have executed) the POST -- re-sending
+        # would double-execute it.
+        route = respx.post(f"{BASE_URL}/query/sync").mock(
+            side_effect=httpx.RemoteProtocolError(TRUNCATED_BODY_MSG)
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        with pytest.raises(TransportConnectionError):
+            client.post_json("/query/sync", body={"q": "x"})
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_get_truncated_body_retries(self):
+        route = respx.get(f"{BASE_URL}/flaky").mock(
+            side_effect=[
+                httpx.RemoteProtocolError(TRUNCATED_BODY_MSG),
+                httpx.Response(200, json={"ok": True}),
+            ]
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        assert client.get_json("/flaky") == {"ok": True}
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_post_write_error_retries_then_succeeds(self):
+        # EPIPE while sending: the RST flavor of a stale pooled connection.
+        # The server cannot process a request it never fully received.
+        route = respx.post(f"{BASE_URL}/query/sync").mock(
+            side_effect=[
+                httpx.WriteError("[Errno 32] Broken pipe"),
+                httpx.Response(200, json={"ok": True}),
+            ]
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        assert client.post_json("/query/sync", body={"q": "x"}) == {"ok": True}
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_post_read_error_maps_without_retry(self):
+        # ECONNRESET while reading the response: the POST may have been
+        # processed, so no retry -- but it must map, not escape raw.
+        route = respx.post(f"{BASE_URL}/query/sync").mock(
+            side_effect=httpx.ReadError("[Errno 54] Connection reset by peer")
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        with pytest.raises(TransportConnectionError):
+            client.post_json("/query/sync", body={"q": "x"})
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_get_read_error_retries_then_succeeds(self):
+        route = respx.get(f"{BASE_URL}/flaky").mock(
+            side_effect=[
+                httpx.ReadError("[Errno 54] Connection reset by peer"),
+                httpx.Response(200, json={"ok": True}),
+            ]
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        assert client.get_json("/flaky") == {"ok": True}
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_proxy_error_maps_without_retry(self):
+        route = respx.get(f"{BASE_URL}/x").mock(
+            side_effect=httpx.ProxyError("407 Proxy Authentication Required")
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        with pytest.raises(TransportConnectionError):
+            client.get_json("/x")
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_unsupported_protocol_maps_without_retry(self):
+        route = respx.post(f"{BASE_URL}/x").mock(
+            side_effect=httpx.UnsupportedProtocol("Request URL is missing scheme")
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        with pytest.raises(TransportConnectionError):
+            client.post_json("/x", body={})
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_post_connect_timeout_retries_then_succeeds(self):
+        # The TCP/TLS handshake never completed, so the request was never
+        # sent -- exactly as retry-safe as ConnectError.
+        route = respx.post(f"{BASE_URL}/query/sync").mock(
+            side_effect=[
+                httpx.ConnectTimeout("timed out"),
+                httpx.Response(200, json={"ok": True}),
+            ]
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        assert client.post_json("/query/sync", body={"q": "x"}) == {"ok": True}
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_post_pool_timeout_retries_then_succeeds(self):
+        # The request never left the local connection pool.
+        route = respx.post(f"{BASE_URL}/query/sync").mock(
+            side_effect=[
+                httpx.PoolTimeout("pool timeout"),
+                httpx.Response(200, json={"ok": True}),
+            ]
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        assert client.post_json("/query/sync", body={"q": "x"}) == {"ok": True}
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_stream_mid_body_failure_maps(self):
+        # The server drops the connection while the caller drains the
+        # stream: no retry is possible (bytes are already consumed), but the
+        # error must surface as TransportConnectionError, not raw httpx.
+        respx.post(f"{BASE_URL}/export").mock(
+            return_value=httpx.Response(200, stream=_FailsMidStream())
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
         with (
-            pytest.raises(TransportConnectionError, match="stale"),
+            pytest.raises(TransportConnectionError, match="streaming"),
             client.post_raw_stream("/export", body={"q": "x"}) as response,
         ):
-            b"".join(response.iter_bytes())
-        assert route.call_count == 2
+            for _ in response.iter_bytes():
+                pass
+
+    @respx.mock
+    def test_stream_error_body_read_failure_still_maps_by_status(self):
+        # 500 whose error body can't be read (connection drops mid-read):
+        # the status alone must still drive the mapping.
+        respx.post(f"{BASE_URL}/fail").mock(
+            return_value=httpx.Response(500, stream=_FailsMidStream())
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        stream = client.post_raw_stream("/fail", body={"q": "x"})
+        with pytest.raises(TransportServerError) as exc_info:
+            stream.__enter__()
+        assert exc_info.value.status_code == 500
+
+    @respx.mock
+    def test_stream_read_timeout_does_not_retry(self):
+        # A timeout waiting for response headers on this POST may mean the
+        # server is still executing it; re-sending could double-submit.
+        route = respx.post(f"{BASE_URL}/export").mock(
+            side_effect=httpx.ReadTimeout("timed out")
+        )
+        client = PicSureClient(base_url=BASE_URL, token=TOKEN)
+
+        stream = client.post_raw_stream("/export", body={"q": "x"})
+        with pytest.raises(TransportConnectionError, match="timed out"):
+            stream.__enter__()
+        assert route.call_count == 1
 
 
 class TestPicSureClientCorrelationHeaders:


### PR DESCRIPTION
## Problem

A long-lived `Session` (e.g. an RStudio kernel via `reticulate`, or a Jupyter kernel open for hours) keeps an `httpx` keep-alive connection pool. When the server/proxy silently closes a pooled connection, the next request fails — as `httpx.RemoteProtocolError` on a clean close (FIN), or `httpx.WriteError`/`httpx.ReadError` when killed with TCP RST.

The transport layer caught only `httpx.ConnectError` and `httpx.TimeoutException`, so these errors were **neither retried nor mapped** to a `PicSure*` exception — they escaped as raw `httpx` errors. This is the intermittent failure users saw that "went away after restarting/reconnecting."

## Fix

`_request` and `post_raw_stream` now catch **all** `httpx.TransportError` through one arm each, driven by shared policy helpers (`_should_retry`, `_connection_failure_message`):

| Failure | Meaning | Retry (once) |
|---|---|---|
| `ConnectError`, `ConnectTimeout`, `PoolTimeout`, `WriteError` | request never (fully) reached the server | all methods |
| `RemoteProtocolError` — "Server disconnected without sending a response" | stale pooled connection; no response ⇒ never processed | all methods |
| `RemoteProtocolError` — other variants (truncated body, malformed response) | server received & may have executed the request | GET only |
| `ReadError`, `ReadTimeout`, `WriteTimeout`, `CloseError` | failed after the request was fully sent | GET only |
| `ProxyError`, `UnsupportedProtocol`, `LocalProtocolError` | deterministic config/client errors | never |

Every failure above maps to `TransportConnectionError` → `PicSureConnectionError`; no raw httpx exception escapes the transport layer.

Notes:
- The `RemoteProtocolError` discrimination matters for correctness: httpx raises the same class when a connection drops **mid-response-body** — i.e. after the server executed a POST — so a blanket retry would double-execute mutations. The message check degrades safely if httpcore ever rewords it (non-GETs simply stop retrying that case).
- `post_raw_stream` also translates **mid-stream** failures (server drops during `iter_bytes()`), keeps status-driven mapping when a 4xx/5xx **error body** can't be read, and no longer retries POST streams on read-timeouts (previously retried unconditionally — a latent double-submit risk).
- No new public API, no `httpx.Limits`/keep-alive tuning, `_MAX_RETRIES` unchanged at 1.

## R adapter

No change — the R adapter is a `reticulate` passthrough and inherits this transport behavior.

## Testing

- 18 new unit tests across `TestPicSureClientStaleConnection` / `TestPicSureClientRetrySafety` + dev-event coverage: recover-on-retry, no-double-send, raw-exception mapping, mid-stream and error-body failures, per-method retry scoping.
- Full suite: **638 passed, 21 skipped**; `ruff check`, `ruff format --check`, `mypy src/` all clean.
- End-to-end via public API: stale disconnects and EPIPE recover transparently on `searchDictionary()`; a truncated-body POST is **not** re-sent and surfaces `PicSureConnectionError`.