### PR TITLE
WIP: Client migration — path-based gateway routing

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -23,12 +23,14 @@ typical session flows:
 3. **Run.** `session.runQuery(query, type=...)` calls the query-run
    service, which splits the `Query` (or bare `Clause` / `ClauseGroup`)
    into a phenotypic filter tree and the output `select` — the filter's own
-   variables folded together with any `includeConcepts` — serializes to v3
-   wire format, POSTs to `/picsure/v3/query/sync`, and parses the response
+   variables folded together with any `includeConcepts` — serializes to the
+   query wire format, POSTs to `/hpds/auth/v3/query/sync` (or
+   `/hpds/open/query/sync` on open sessions), and parses the response
    into a `CountResult`, a `dict[str, CountResult]`, or a
-   `DataFrame`.
+   `DataFrame`. The gateway selects the HPDS backend by path (`auth` vs
+   `open`), so no `resourceUUID` is sent in the body.
 4. **Export.** `session.exportAsPFB(...)` uses the async flow
-   (`/picsure/v3/query` → poll status → fetch result), streaming the
+   (`/hpds/auth/v3/query` → poll status → fetch result), streaming the
    bytes to disk; `session.exportCSV` / `exportTSV` write a DataFrame
    in memory to disk.
 
@@ -42,14 +44,14 @@ picsure._models.session.Session.runQuery
   │  (decorated with @timed for dev-mode events)
   ▼
 picsure._services.query_run.run_query
-  │  build_query_body(query, resource_uuid, query_type)
+  │  build_query_body(query, query_type)
   │      ├─ Clause.to_query_json()  /  ClauseGroup.to_query_json()
-  │      └─ wraps in v3 envelope { query: { ... }, resourceUUID }
+  │      └─ wraps in envelope { query: { ... } }  (no resourceUUID)
   │
-  │  client.post_json(_PICSURE_QUERY_SYNC_PATH, body)
+  │  client.post_raw(query_prefix(backend, v3=...) + "/query/sync", body)
   ▼
 picsure._transport.client.PicSureClient._request
-  │  httpx.Client.request("POST", "/picsure/v3/query/sync", ...)
+  │  httpx.Client.request("POST", "/hpds/auth/v3/query/sync", ...)
   │  4xx → _raise_for_status → TransportAuthenticationError /
   │        TransportValidationError / TransportNotFoundError /
   │        TransportRateLimitError
@@ -87,7 +89,7 @@ src/picsure/
 | Module             | What it owns                                                                 |
 |--------------------|------------------------------------------------------------------------------|
 | `session.py`       | `Session` class. Holds the HTTP client, resource list, consents, dictionary size, and the dev-mode config. Public methods (`searchDictionary`, `runQuery`, `runQueryByID`, `loadQueryByID`, `saveQueryByName`, `exportAsPFB`, `exportCSV`, `exportTSV`, `setResourceID`, `setResourceIDByName`, `getResourceID`, `facets`, `showAllFacets`, …) delegate to `_services/*`. |
-| `resource.py`      | `Resource` dataclass (`uuid`, `name`, `description`) with a `from_dict` constructor for `/picsure/info/resources` payloads. |
+| `resource.py`      | `Resource` dataclass (`uuid`, `name`, `description`) with a `from_dict` constructor. Retained for the `getResourceID` / `setResourceIDByName` surface; the resource registry it used to be populated from has been removed. |
 | `clause.py`        | `Clause` dataclass + `PhenotypicFilterType` enum (`FILTER`, `ANYRECORD`, `REQUIRE`). Each `Clause.to_query_json()` emits the v3 `PhenotypicClause` shape. |
 | `clause_group.py`  | `ClauseGroup` dataclass + `GroupOperator` enum (`AND`, `OR`). Recursively serializes to a v3 `PhenotypicSubquery`. |
 | `query.py`         | `Query` dataclass: a `phenotypicFilter` (`Clause | ClauseGroup | None`) plus `includeConcepts` (output concept paths). `runQuery` also accepts a bare `Clause` / `ClauseGroup` (filter; its variables are returned as output columns). `concept_paths()` on each collects the filter's variables to fold into `select`. |
@@ -100,13 +102,14 @@ src/picsure/
 
 | Module           | What it owns                                                                 |
 |------------------|------------------------------------------------------------------------------|
-| `connect.py`     | `connect(platform, token, …)`. Resolves the platform, fetches resources and (on authorized deployments) consents, and constructs the `Session`. Reads the display email and expiry straight from the JWT — no `/psama/user/me` round trip. Also handles the dev-mode toggle and the success/expiration banner. |
+| `connect.py`     | `connect(platform, token, …)`. Resolves the platform, fetches consents on consent-gated deployments, and constructs the `Session` with its HPDS `backend` (`auth`/`open`). There is no resource-registry round trip — the gateway routes by path. Reads the display email and expiry straight from the JWT — no `/psama/user/me` round trip. Also handles the dev-mode toggle and the success/expiration banner. |
 | `search.py`      | `searchDictionary`, `fetch_facets`, `show_all_facets`, plus the smaller helpers that build dictionary-api request bodies, dedupe entries, and turn results into DataFrames. Dictionary searches use a single max-int page (`_MAX_PAGE_SIZE`) so one request returns every concept. |
 | `query_build.py` | `buildClause`, `buildClauseGroup`, and `buildQuery` — the public constructors for `Clause`, `ClauseGroup`, and `Query` with input validation (rejects mutually-exclusive arguments before they reach the wire). |
 | `query_edit.py`  | `removeSubQuery(query, target)` and `replaceClause(query, target, replacement)`. Pure local tree edits — no network calls. Matching is structural (frozen-dataclass equality). Removals that empty a `ClauseGroup` prune the parent; removing the whole tree raises `PicSureValidationError`. |
-| `query_run.py`   | `run_query(client, resource_uuid, query, type)`. Serializes via `build_query_body`, posts to the v3 sync endpoint (or the legacy path on open-only deployments), and parses each response shape. Also `parse_count_string` for the obfuscated-count regexes. |
-| `query_load.py`  | `load_query(client, query_id)`. Hits the saved-query endpoint and reconstructs a `Clause` / `ClauseGroup` from the response so it can be re-run via `runQueryByID`. |
-| `query_save.py`  | `save_query_by_name(client, resource_uuid, query, name, *, use_legacy_query_path, overwrite)`. Submits the query via `POST /picsure/v3/query`, then `POST`s a new record to `/dataset/named/` (or `PUT`-updates an existing one when `overwrite=True`). Validates `name` against the backend `NamedDataset` pattern client-side. Refused on open-access deployments. |
+| `query_run.py`   | `run_query(client, query, type, *, backend)`. Serializes via `build_query_body`, posts to `/hpds/{backend}[/v3]/query/sync` (`auth` uses v3, `open` uses v1), and parses each response shape. Also `parse_count_string` for the obfuscated-count regexes. HPDS route helpers live in `_hpds_paths.py`. |
+| `query_load.py`  | `load_query(client, query_id, *, backend)`. Hits `/hpds/{backend}/query/{id}/metadata` (version-agnostic) and reconstructs a `Clause` / `ClauseGroup` from the response so it can be re-run via `runQueryByID`. |
+| `query_save.py`  | `save_query_by_name(client, query, name, *, backend, overwrite)`. Submits the query via `POST /hpds/auth/v3/query`, then `POST`s a new record to `/dataset/named/` (or `PUT`-updates an existing one when `overwrite=True`). Validates `name` against the backend `NamedDataset` pattern client-side. Refused on open-access (`open` backend) deployments. |
+| `_hpds_paths.py` | `query_prefix(backend, *, v3)` and `search_values_path(backend)` — the single place the `/hpds/{auth,open}[/v3]/…` route shape (and the ignored search `{resourceId}` placeholder) is built. |
 | `export.py`      | `export_pfb` — the async PFB flow (submit → poll with exponential backoff capped at 60s, 10-minute total deadline → stream result to a `.part` file → atomic rename). Plus `export_csv` and `export_tsv` for in-memory DataFrames. |
 | `consents.py`    | `fetch_consents(client)`. Reads `/psama/user/me/queryTemplate/`, parses the doubly-encoded JSON, and pulls the `\\_consents\\` study-consent list used by dictionary-api requests on authorized deployments. |
 
@@ -210,19 +213,23 @@ small:
   knows the base URL and token).
 - `_user_email`, `_token_expiration` — surfaced in the connect
   banner; `_user_email == "anonymous"` on open-access deployments.
-- `_resources` — `list[Resource]` from `/picsure/info/resources`.
-- `_resource_uuid` — the currently active resource. Defaulted from
-  the `Platform` member at connect time, or required to be set
-  manually for custom URLs.
+- `_resources` — `list[Resource]`, empty now that the resource
+  registry is gone (retained for the `getResourceID` /
+  `setResourceIDByName` surface).
+- `_resource_uuid` — a UUID stored via `setResourceID` /
+  `connect(resource_uuid=…)`. Retained for backwards compatibility; it
+  no longer selects a backend or appears in query bodies.
 - `_consents` — `list[str]` of study-consent identifiers. Empty on
   open-access; required in dictionary-api request bodies on
   authorized deployments.
 - `_dev_config` — opt-in `DevConfig` (off by default).
-- `_use_legacy_query_path` — set during connect when the platform is
-  open-only and must use `/picsure/query/sync` (BDC's API gateway
-  rejects open traffic on the v3 endpoint with HTTP 401).
+- `_backend` — `"auth"` or `"open"`, set during connect. Selects the
+  HPDS backend by URL path (`/hpds/auth` vs `/hpds/open`) and, with it,
+  the v3-vs-v1 query lifecycle. Open-only deployments use `/hpds/open`
+  (v1) because BDC's gateway rejects open traffic on the v3 endpoint.
 
-Resources are resolved by UUID by default. Two name-based helpers
+The resource-selection methods are retained for source compatibility
+but no longer drive routing. Two name-based helpers
 exist for ergonomics: `setResourceIDByName(name)` looks up by the
 backend's `name` field on `Resource`. Platform labels like
 `BDC Authorized` and `BDC Open` are display-only (printed on connect,

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -52,7 +52,7 @@ import respx
 from picsure._services.query_run import run_query
 
 BASE_URL = "https://test.example.com"
-QUERY_URL = f"{BASE_URL}/picsure/v3/query/sync"
+QUERY_URL = f"{BASE_URL}/hpds/auth/v3/query/sync"
 
 
 class TestRunQueryCount:
@@ -62,7 +62,7 @@ class TestRunQueryCount:
             return_value=httpx.Response(200, content=b"1234")
         )
         client = _make_client()
-        result = run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+        result = run_query(client, _simple_clause(), "count", backend="auth")
         assert result.value == 1234
 ```
 

--- a/src/picsure/_dev/redaction.py
+++ b/src/picsure/_dev/redaction.py
@@ -51,7 +51,7 @@ def redact_for_log(
         return json.dumps(_redact_psama_secrets(body))
 
     # Suppress based on body SHAPE, not path: the async PFB export posts the
-    # same participant-bearing query body to /picsure/v3/query (and
+    # same participant-bearing query body to /hpds/auth/v3/query (and
     # /status, /result), none of which end in /query/sync.
     if _body_is_participant_like(body):
         return None

--- a/src/picsure/_models/clause.py
+++ b/src/picsure/_models/clause.py
@@ -48,7 +48,7 @@ class Clause:
 
     **Wire format.** :meth:`to_query_json` emits a v3 ``PhenotypicFilter``
     leaf (or an ``OR`` ``PhenotypicSubquery`` of leaves for multi-key
-    clauses) per the ``/picsure/v3/query/sync`` contract.
+    clauses) per the ``/hpds/{auth,open}[/v3]/query`` contract.
     """
 
     keys: list[str]

--- a/src/picsure/_models/clause_group.py
+++ b/src/picsure/_models/clause_group.py
@@ -27,7 +27,7 @@ class ClauseGroup:
 
     **Wire format.** :meth:`to_query_json` emits a v3
     ``PhenotypicSubquery`` (``operator`` / ``phenotypicClauses``) per
-    the ``/picsure/v3/query/sync`` contract. The previous wire format
+    the ``/hpds/{auth,open}[/v3]/query`` contract. The previous wire format
     is not supported.
     """
 

--- a/src/picsure/_models/genomic_filter.py
+++ b/src/picsure/_models/genomic_filter.py
@@ -57,7 +57,7 @@ class GenomicFilter:
     A filter matches when the annotation named by ``key`` is one of ``values``.
 
     **Wire format.** :meth:`to_query_json` emits a v3 ``GenomicFilter`` record
-    (``{"key", "values"?}``) per the ``/picsure/v3/query/sync`` contract.
+    (``{"key", "values"?}``) per the ``/hpds/{auth,open}[/v3]/query`` contract.
     """
 
     key: str

--- a/src/picsure/_models/session.py
+++ b/src/picsure/_models/session.py
@@ -35,22 +35,25 @@ class Session:
         client: PicSureClient,
         user_email: str,
         token_expiration: str,
-        resources: list[Resource],
+        resources: list[Resource] | None = None,
         resource_uuid: str | None = None,
         consents: list[str] | None = None,
         dev_config: DevConfig | None = None,
-        use_legacy_query_path: bool = False,
+        backend: str = "auth",
         supports_genomic: bool = False,
         session_id: str = "",
     ) -> None:
         self._client = client
         self._user_email = user_email
         self._token_expiration = token_expiration
-        self._resources = resources
+        self._resources = list(resources) if resources else []
         self._resource_uuid = resource_uuid
         self._session_id = session_id
         self._consents: list[str] = list(consents) if consents else []
-        self._use_legacy_query_path = use_legacy_query_path
+        # "auth" or "open": selects the HPDS backend by URL path
+        # (/hpds/auth vs /hpds/open) and, with it, the v3 vs v1 query
+        # lifecycle.  Replaces the old resource-UUID backend selection.
+        self._backend = backend
         self._supports_genomic = supports_genomic
         self._dev_config = (
             dev_config
@@ -79,7 +82,14 @@ class Session:
         return list(self._consents)
 
     def getResourceID(self) -> pd.DataFrame:
-        """Return resource IDs and metadata as a DataFrame."""
+        """Return resource IDs and metadata as a DataFrame.
+
+        The resource registry has been removed — the gateway now selects
+        the HPDS backend by URL path rather than by a discovered resource
+        UUID — so this returns an empty frame unless a UUID was passed to
+        :func:`picsure.connect` or :meth:`setResourceID`.  Retained for
+        backwards compatibility; it no longer drives which data is queried.
+        """
         if not self._resources:
             return pd.DataFrame(columns=["uuid", "name", "description"])
         return pd.DataFrame(
@@ -94,15 +104,17 @@ class Session:
         )
 
     def setResourceID(self, resource_uuid: str) -> None:
-        """Set the active resource UUID for searches and queries.
+        """Set the resource UUID stored on this session.
+
+        Deprecated: the gateway selects the HPDS backend by URL path
+        (``/hpds/auth`` vs ``/hpds/open``), derived from the platform, so
+        the stored UUID no longer chooses a backend and is not sent in
+        query bodies.  Retained for backwards compatibility.  With the
+        resource registry removed there is nothing to validate against,
+        so any value is accepted.
 
         Args:
-            resource_uuid: The UUID of the resource to use. See
-                ``getResourceID()`` for available resources.
-
-        Raises:
-            PicSureValidationError: If the UUID does not match any
-                resource on this connection.
+            resource_uuid: A resource UUID to store on the session.
         """
         known_uuids = {r.uuid for r in self._resources}
         if known_uuids and resource_uuid not in known_uuids:
@@ -284,8 +296,8 @@ class Session:
 
         return search_genomic_values(
             self._client,
-            self._default_resource_uuid(),
             genomicConceptPath,
+            backend=self._backend,
             query=query,
             page=page,
             size=size,
@@ -345,10 +357,9 @@ class Session:
 
         return run_query(
             self._client,
-            self._default_resource_uuid(),
             query,
             type,
-            use_legacy_query_path=self._use_legacy_query_path,
+            backend=self._backend,
         )
 
     @timed("session.exportAsPFB")
@@ -372,7 +383,7 @@ class Session:
             PicSureValidationError: If the session was connected to an
                 open-access platform.
         """
-        if self._use_legacy_query_path:
+        if self._backend == "open":
             raise PicSureValidationError(
                 "PFB export is not supported on open-access platforms. "
                 "Connect with an authorized platform (e.g. "
@@ -383,9 +394,9 @@ class Session:
 
         export_pfb(
             self._client,
-            self._default_resource_uuid(),
             query,
             path,
+            backend=self._backend,
         )
 
     @timed("session.saveQueryByName")
@@ -419,10 +430,9 @@ class Session:
 
         return save_query_by_name(
             self._client,
-            self._default_resource_uuid(),
             query,
             name,
-            use_legacy_query_path=self._use_legacy_query_path,
+            backend=self._backend,
             overwrite=overwrite,
         )
 
@@ -524,7 +534,7 @@ class Session:
         """
         from picsure._services.query_load import load_query
 
-        return load_query(self._client, query_id)
+        return load_query(self._client, query_id, backend=self._backend)
 
     def close(self) -> None:
         """Close the underlying HTTP client and release its connection pool.
@@ -572,21 +582,3 @@ class Session:
                 "(e.g. Platform.BDC_AUTHORIZED); this session is connected "
                 "to an open or non-genomic resource."
             )
-
-    def _default_resource_uuid(self) -> str:
-        if self._resource_uuid is not None:
-            return self._resource_uuid
-        if not self._resources:
-            raise PicSureValidationError(
-                "No resources are available on this connection. "
-                "Check with your administrator."
-            )
-        if len(self._resources) == 1:
-            return self._resources[0].uuid
-        listing = "\n".join(f"  {r.uuid}  {r.name}" for r in self._resources)
-        raise PicSureValidationError(
-            "This connection has multiple resources and none has been "
-            "selected. Call session.setResourceID(uuid) to choose one "
-            "before searching or querying.\n\n"
-            f"Available resources:\n{listing}"
-        )

--- a/src/picsure/_services/_hpds_paths.py
+++ b/src/picsure/_services/_hpds_paths.py
@@ -10,12 +10,6 @@ from __future__ import annotations
 # deployment where open-access traffic is served only on v1 and authorized
 # traffic on v3.
 
-# Search routes keep a ``{resourceId}`` path segment for ingress-contract
-# parity, but the query-service ignores it for routing (the backend is chosen
-# by the ``/hpds/{auth,open}`` prefix).  It must still parse as a UUID, so we
-# send a fixed all-zero placeholder rather than a resource-selection UUID.
-_PLACEHOLDER_RESOURCE_ID = "00000000-0000-0000-0000-000000000000"
-
 
 def query_prefix(backend: str, *, v3: bool) -> str:
     """Return the HPDS query-lifecycle path prefix for a backend.
@@ -36,7 +30,7 @@ def query_prefix(backend: str, *, v3: bool) -> str:
 def search_values_path(backend: str) -> str:
     """Return the HPDS search-values path for a backend.
 
-    The ``{resourceId}`` segment is a UUID-parseable placeholder that the
-    query-service ignores (see :data:`_PLACEHOLDER_RESOURCE_ID`).
+    The registry-era ``{resourceId}`` placeholder segment is gone: the
+    well-defined ingress is ``/hpds/{backend}/search/values``.
     """
-    return f"/hpds/{backend}/search/{_PLACEHOLDER_RESOURCE_ID}/values/"
+    return f"/hpds/{backend}/search/values"

--- a/src/picsure/_services/_hpds_paths.py
+++ b/src/picsure/_services/_hpds_paths.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+# The PIC-SURE gateway routes HPDS traffic by URL path, not by a resource
+# UUID in the request body: ``/hpds/auth/**`` reaches the authorized
+# (non-obfuscated) HPDS and ``/hpds/open/**`` the open (aggregate/obfuscated)
+# one.  The backend is a path segment; the version is a ``/v3`` sub-prefix.
+#
+# The adapter keeps today's split: authorized sessions use the v3 query
+# routes, open sessions the v1 (non-versioned) routes — matching the
+# deployment where open-access traffic is served only on v1 and authorized
+# traffic on v3.
+
+# Search routes keep a ``{resourceId}`` path segment for ingress-contract
+# parity, but the query-service ignores it for routing (the backend is chosen
+# by the ``/hpds/{auth,open}`` prefix).  It must still parse as a UUID, so we
+# send a fixed all-zero placeholder rather than a resource-selection UUID.
+_PLACEHOLDER_RESOURCE_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def query_prefix(backend: str, *, v3: bool) -> str:
+    """Return the HPDS query-lifecycle path prefix for a backend.
+
+    Args:
+        backend: ``"auth"`` or ``"open"`` — selects the HPDS instance by
+            path (replaces the legacy resource-UUID selection).
+        v3: When ``True``, target the ``/v3`` query routes; otherwise the
+            v1 (non-versioned) routes.
+
+    Returns:
+        A path prefix such as ``"/hpds/auth/v3"`` or ``"/hpds/open"``, to
+        which a ``/query`` suffix is appended by the caller.
+    """
+    return f"/hpds/{backend}/v3" if v3 else f"/hpds/{backend}"
+
+
+def search_values_path(backend: str) -> str:
+    """Return the HPDS search-values path for a backend.
+
+    The ``{resourceId}`` segment is a UUID-parseable placeholder that the
+    query-service ignores (see :data:`_PLACEHOLDER_RESOURCE_ID`).
+    """
+    return f"/hpds/{backend}/search/{_PLACEHOLDER_RESOURCE_ID}/values/"

--- a/src/picsure/_services/connect.py
+++ b/src/picsure/_services/connect.py
@@ -9,22 +9,13 @@ from uuid import uuid4
 
 from picsure._dev.config import DevConfig
 from picsure._dev.events import Event
-from picsure._models.resource import Resource
 from picsure._models.session import Session
 from picsure._services.consents import fetch_consents
 from picsure._transport.client import PicSureClient
-from picsure._transport.errors import (
-    TransportAuthenticationError,
-    TransportError,
-)
 from picsure._transport.platforms import Platform, resolve_platform
 from picsure.errors import (
-    PicSureAuthError,
-    PicSureConnectionError,
     PicSureValidationError,
 )
-
-_PICSURE_RESOURCES_PATH = "/picsure/info/resources"
 
 _ANONYMOUS_EMAIL = "anonymous"
 _ANONYMOUS_EXPIRATION = "N/A"
@@ -52,10 +43,12 @@ def connect(
         token: Your PIC-SURE API token.  Leave empty for open-access
             platforms (e.g. ``Platform.BDC_OPEN``) that don't require
             authentication.
-        resource_uuid: Optional resource UUID to use. Overrides the
-            default UUID from the Platform enum. Required for custom
-            URLs — if omitted, call ``session.setResourceID(uuid)``
-            after reviewing ``session.getResourceID()``.
+        resource_uuid: Deprecated and no longer used for routing. The
+            gateway now selects the HPDS backend by URL path
+            (``/hpds/auth`` vs ``/hpds/open``), derived from the
+            platform, so a resource UUID no longer chooses a backend.
+            Accepted for backwards compatibility and stored on the
+            session, but it does not affect which data is queried.
         include_consents: Override the platform's consent policy.  For
             known Platform members this defaults to the member's own
             flag; for custom URLs it defaults to ``False``.  Pass
@@ -150,26 +143,16 @@ def connect(
         email = _ANONYMOUS_EMAIL
         expiration = _ANONYMOUS_EXPIRATION
 
-    resources = _fetch_resources(client, display_name, info.url, info.requires_auth)
+    # The resource registry (/info/resources) is gone: the gateway routes
+    # by URL path, not by a resource UUID discovered from a registry, so
+    # there is no discovery round-trip on connect.
     consents = fetch_consents(client) if info.include_consents else []
-
-    # Explicit resource_uuid wins, then Platform default, then None.
-    effective_uuid = resource_uuid if resource_uuid is not None else info.resource_uuid
 
     if info.requires_auth:
         print(f"You're successfully connected to {display_name} as user {email}!")
         print(f"Your token expires on {expiration}.")
     else:
         print(f"You're successfully connected to {display_name} (open access).")
-
-    if effective_uuid is None and resources:
-        print("\nAvailable resources:")
-        for r in resources:
-            print(f"  {r.uuid}  {r.name}")
-        print(
-            "\nNo resource selected. Use session.setResourceID(uuid) "
-            "to choose a resource before searching or querying."
-        )
 
     if dev_config.enabled:
         dev_config.emit(
@@ -184,29 +167,27 @@ def connect(
                 retry=0,
                 error=None,
                 metadata={
-                    "resources": len(resources),
                     "consents": len(consents),
                     "requires_auth": info.requires_auth,
                 },
             )
         )
 
-    # BDC's API gateway gates the v3 sync query endpoint as
-    # authorized-only.  Open-only deployments (no auth, no consents)
-    # must hit the legacy /picsure/query/sync path or every runQuery
-    # call will 401.  Authorized and consent-gated deployments stay on
-    # v3 since that's where their backend exposes the query API.
-    use_legacy_query_path = not info.requires_auth and not info.include_consents
+    # HPDS backend is chosen by URL path, not a resource UUID: open-access
+    # deployments (no auth, no consents) route to /hpds/open and use the v1
+    # query lifecycle; authorized and consent-gated deployments route to
+    # /hpds/auth and use v3.  This preserves the split where BDC's gateway
+    # serves open-access traffic only on v1 and authorized traffic on v3.
+    backend = "open" if not info.requires_auth and not info.include_consents else "auth"
 
     return Session(
         client=client,
         user_email=email,
         token_expiration=expiration,
-        resources=resources,
-        resource_uuid=effective_uuid,
+        resource_uuid=resource_uuid,
         consents=consents,
         dev_config=dev_config,
-        use_legacy_query_path=use_legacy_query_path,
+        backend=backend,
         supports_genomic=info.supports_genomic,
         session_id=session_id,
     )
@@ -290,43 +271,3 @@ def _install_default_handler() -> None:
     handler.setFormatter(logging.Formatter("%(name)s %(message)s"))
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
-
-
-def _fetch_resources(
-    client: PicSureClient, display_name: str, base_url: str, requires_auth: bool
-) -> list[Resource]:
-    try:
-        data = client.get_json(_PICSURE_RESOURCES_PATH)
-    except TransportAuthenticationError as exc:
-        # Open-access deployments may gate /info/resources behind auth
-        # even though the dictionary-api is public.  Silently degrade
-        # to no resources so search/facets still work.
-        if not requires_auth:
-            return []
-        # On auth deployments this is the first authenticated call, so
-        # it owns the friendly "your token is bad" message that the
-        # /psama/user/me handshake used to surface.
-        raise PicSureAuthError(
-            "Your token is invalid or expired. Generate a new one at "
-            f"{base_url} and pass it to picsure.connect()."
-        ) from exc
-    except TransportError as exc:
-        raise PicSureConnectionError(
-            f"Connected to {display_name} but could not fetch resources. "
-            "The server may be temporarily unavailable."
-        ) from exc
-
-    if isinstance(data, dict):
-        return [
-            Resource(uuid=uuid, name=str(name), description="")
-            for uuid, name in data.items()
-        ]
-
-    if not isinstance(data, list):
-        raise PicSureConnectionError(
-            f"Connected to {display_name} but received an unexpected "
-            "resources response from the server. The server may be "
-            "misconfigured or temporarily unavailable."
-        )
-
-    return [Resource.from_dict(r) for r in data if isinstance(r, dict)]

--- a/src/picsure/_services/export.py
+++ b/src/picsure/_services/export.py
@@ -11,6 +11,7 @@ from picsure._models.clause import Clause
 from picsure._models.clause_group import ClauseGroup
 from picsure._models.query import Query
 from picsure._services._errors import translate_stage_error
+from picsure._services._hpds_paths import query_prefix
 from picsure._services.query_run import build_query_body
 from picsure._transport.client import PicSureClient
 from picsure._transport.errors import TransportError
@@ -18,10 +19,6 @@ from picsure.errors import (
     PicSureConnectionError,
     PicSureQueryError,
 )
-
-_QUERY_SUBMIT_PATH = "/picsure/v3/query"
-_STATUS_PATH_TEMPLATE = "/picsure/v3/query/{query_id}/status"
-_RESULT_PATH_TEMPLATE = "/picsure/v3/query/{query_id}/result"
 
 # Terminal status values returned by PIC-SURE's ``PicSureStatus`` enum.
 # Only AVAILABLE (success) and ERROR (failure) are terminal; every other
@@ -41,20 +38,21 @@ _TOTAL_TIMEOUT_SECONDS = 600.0
 
 def export_pfb(
     client: PicSureClient,
-    resource_uuid: str,
     query: Query | Clause | ClauseGroup,
     path: str | Path,
+    *,
+    backend: str,
 ) -> None:
     """Execute a query and stream the PFB result to disk.
 
-    Uses PIC-SURE's async flow (v3):
+    Uses PIC-SURE's async flow on the authorized v3 routes:
 
-    1. ``POST /picsure/v3/query`` — submit the query, receive a query id.
-    2. ``POST /picsure/v3/query/{id}/status`` — poll with exponential
+    1. ``POST /hpds/auth/v3/query`` — submit the query, receive a query id.
+    2. ``POST /hpds/auth/v3/query/{id}/status`` — poll with exponential
        backoff (1s, 2s, 4s, ..., capped at 60s per poll) until the
        server reports ``AVAILABLE``.  Total elapsed time is bounded at
        10 minutes.
-    3. ``POST /picsure/v3/query/{id}/result`` — stream the Avro-binary
+    3. ``POST /hpds/auth/v3/query/{id}/result`` — stream the Avro-binary
        PFB bytes straight to disk.
 
     The output file is written atomically: bytes land at
@@ -64,10 +62,11 @@ def export_pfb(
 
     Args:
         client: Authenticated HTTP client.
-        resource_uuid: The resource to query.
         query: A Clause or ClauseGroup.
         path: File path to write the PFB data to.  Accepts ``str`` or
             :class:`pathlib.Path`.
+        backend: ``"auth"`` — PFB export is only supported on authorized
+            sessions (the caller rejects ``"open"`` before reaching here).
 
     Raises:
         PicSureValidationError: If the server rejects the request
@@ -83,25 +82,27 @@ def export_pfb(
     target = Path(path)
     part_path = target.with_suffix(target.suffix + ".part")
 
-    body = build_query_body(query, resource_uuid, "DATAFRAME_PFB")
+    base = query_prefix(backend, v3=True)
+    body = build_query_body(query, "DATAFRAME_PFB")
 
     # 1. Submit the query.
-    submit_response = _submit_query(client, body)
+    submit_response = _submit_query(client, base, body)
     query_id = _extract_query_id(submit_response)
 
     # 2. Poll until AVAILABLE (or timeout / error).
-    _poll_until_available(client, query_id, body)
+    _poll_until_available(client, base, query_id, body)
 
     # 3. Stream the result to disk atomically.
-    _download_result(client, query_id, body, target, part_path)
+    _download_result(client, base, query_id, body, target, part_path)
 
 
 def _submit_query(
     client: PicSureClient,
+    base: str,
     body: dict[str, object],
 ) -> dict[str, object]:
     try:
-        return client.post_json(_QUERY_SUBMIT_PATH, body=body)
+        return client.post_json(f"{base}/query", body=body)
     except TransportError as exc:
         raise translate_stage_error(exc, service="PFB", stage="submit") from exc
 
@@ -126,10 +127,11 @@ def _extract_query_id(response: dict[str, object]) -> str:
 
 def _poll_until_available(
     client: PicSureClient,
+    base: str,
     query_id: str,
     body: dict[str, object],
 ) -> None:
-    status_path = _STATUS_PATH_TEMPLATE.format(query_id=query_id)
+    status_path = f"{base}/query/{query_id}/status"
 
     interval = _INITIAL_POLL_INTERVAL_SECONDS
     start = time.monotonic()
@@ -179,12 +181,13 @@ def _extract_status(response: dict[str, object]) -> str:
 
 def _download_result(
     client: PicSureClient,
+    base: str,
     query_id: str,
     body: dict[str, object],
     target: Path,
     part_path: Path,
 ) -> None:
-    result_path = _RESULT_PATH_TEMPLATE.format(query_id=query_id)
+    result_path = f"{base}/query/{query_id}/result"
 
     try:
         with client.post_raw_stream(result_path, body=body) as response:

--- a/src/picsure/_services/genomic_search.py
+++ b/src/picsure/_services/genomic_search.py
@@ -5,6 +5,7 @@ from urllib.parse import urlencode
 import pandas as pd
 
 from picsure._services._errors import rate_limit_message
+from picsure._services._hpds_paths import search_values_path
 from picsure._transport.client import PicSureClient
 from picsure._transport.errors import (
     TransportAuthenticationError,
@@ -20,19 +21,21 @@ from picsure.errors import (
     PicSureValidationError,
 )
 
-_VALUES_PATH = "/picsure/search/{resource_uuid}/values/"
-
 
 def search_genomic_values(
     client: PicSureClient,
-    resource_uuid: str,
     genomic_concept_path: str,
     *,
+    backend: str,
     query: str = "",
     page: int = 1,
     size: int = 50,
 ) -> pd.DataFrame:
     """Fetch one page of valid values for a genomic annotation key.
+
+    Hits ``/hpds/{backend}/search/{resourceId}/values/`` — the backend is
+    chosen by URL path and the ``{resourceId}`` segment is an ignored
+    placeholder (see :func:`picsure._services._hpds_paths.search_values_path`).
 
     Returns a single-column (``value``) DataFrame. Pagination metadata is
     preserved on ``df.attrs``: ``total``, ``page``, ``size``,
@@ -51,7 +54,7 @@ def search_genomic_values(
             "size": size,
         }
     )
-    path = _VALUES_PATH.format(resource_uuid=resource_uuid) + "?" + params
+    path = search_values_path(backend) + "?" + params
 
     try:
         data = client.get_json(path)

--- a/src/picsure/_services/genomic_search.py
+++ b/src/picsure/_services/genomic_search.py
@@ -33,9 +33,8 @@ def search_genomic_values(
 ) -> pd.DataFrame:
     """Fetch one page of valid values for a genomic annotation key.
 
-    Hits ``/hpds/{backend}/search/{resourceId}/values/`` — the backend is
-    chosen by URL path and the ``{resourceId}`` segment is an ignored
-    placeholder (see :func:`picsure._services._hpds_paths.search_values_path`).
+    Hits ``/hpds/{backend}/search/values`` — the backend is chosen by URL
+    path (see :func:`picsure._services._hpds_paths.search_values_path`).
 
     Returns a single-column (``value``) DataFrame. Pagination metadata is
     preserved on ``df.attrs``: ``total``, ``page``, ``size``,

--- a/src/picsure/_services/query_load.py
+++ b/src/picsure/_services/query_load.py
@@ -176,25 +176,30 @@ def _to_query(
     )
 
 
-# Always use the legacy /picsure/query/{id}/metadata path.  The v3
-# /picsure/v3/query/{id}/metadata endpoint has a known issue on BDC, so
-# we pin reads to legacy regardless of how the session was connected.
-_PICSURE_QUERY_METADATA_PATH = "/picsure/query/{query_id}/metadata"
+# Query metadata is version-agnostic in the query-service (it reads the
+# stored query, not HPDS), so we use the non-versioned metadata route.  The
+# {backend} segment is required for routing but the read does not depend on
+# which backend is named.
+_HPDS_QUERY_METADATA_PATH = "/hpds/{backend}/query/{query_id}/metadata"
 
 
 def load_query(
     client: PicSureClient,
     query_id: str,
+    *,
+    backend: str,
 ) -> Query | Clause | ClauseGroup:
     """Load a previously-saved query by ID and rebuild it as a Query.
 
-    Always uses ``/picsure/query/{id}/metadata`` (legacy) — the v3
-    metadata endpoint is currently broken on BDC, so we read via legacy
-    for every deployment.
+    Reads ``/hpds/{backend}/query/{id}/metadata``.  Query metadata is
+    version-agnostic in the query-service (it reads the stored query row,
+    not HPDS), so the non-versioned route is used for every session.
 
     Args:
         client: Authenticated HTTP client.
         query_id: The UUID string of a previous query.
+        backend: ``"auth"`` or ``"open"`` — the HPDS backend segment for
+            the metadata route (does not affect the metadata read itself).
 
     Returns:
         A :class:`Clause` or :class:`ClauseGroup` that can be passed
@@ -213,7 +218,7 @@ def load_query(
         raise PicSureValidationError(
             "A non-empty query ID is required to load a saved query."
         )
-    path = _PICSURE_QUERY_METADATA_PATH.format(query_id=query_id.strip())
+    path = _HPDS_QUERY_METADATA_PATH.format(backend=backend, query_id=query_id.strip())
 
     try:
         response = client.get_json(path)

--- a/src/picsure/_services/query_run.py
+++ b/src/picsure/_services/query_run.py
@@ -13,6 +13,7 @@ from picsure._models.genomic_filter import GenomicFilter
 from picsure._models.query import Query
 from picsure._models.query_type import QueryType
 from picsure._services._errors import rate_limit_message
+from picsure._services._hpds_paths import query_prefix
 from picsure._transport.client import PicSureClient
 from picsure._transport.errors import (
     TransportError,
@@ -26,12 +27,6 @@ from picsure.errors import (
     PicSureQueryError,
     PicSureValidationError,
 )
-
-_PICSURE_QUERY_SYNC_PATH = "/picsure/v3/query/sync"
-# BDC's API gateway gates the v3 sync endpoint as authorized-only and
-# rejects open-access requests with 401 even when "request-source: Open"
-# is set.  Open-only deployments must use the legacy path instead.
-_PICSURE_QUERY_SYNC_PATH_LEGACY = "/picsure/query/sync"
 
 _VALID_QUERY_TYPES: dict[str, str] = {
     "count": "COUNT",
@@ -64,27 +59,25 @@ _COUNT_SUPPRESSED = re.compile(r"^<\s*(\d+)$")
 
 def run_query(
     client: PicSureClient,
-    resource_uuid: str,
     query: Query | Clause | ClauseGroup,
     query_type: QueryType | str,
     *,
-    use_legacy_query_path: bool = False,
+    backend: str,
 ) -> CountResult | dict[str, CountResult] | pd.DataFrame | list[str]:
     """Execute a query against PIC-SURE and return the result.
 
     Args:
         client: Authenticated HTTP client.
-        resource_uuid: The resource to query.
         query: A Query, Clause, or ClauseGroup built with
             buildQuery/buildClause/buildClauseGroup.
         query_type: A :class:`QueryType` member (e.g. ``QueryType.COUNT``)
             or one of the strings ``"count"``, ``"participant"``,
             ``"timestamp"``, ``"cross_count"``.
-        use_legacy_query_path: When ``True``, send the request to the
-            legacy ``/picsure/query/sync`` endpoint instead of the v3
-            path.  Open-only deployments (no auth, no consents) must
-            use the legacy path because the BDC API gateway rejects
-            open-access traffic on the v3 endpoint with HTTP 401.
+        backend: ``"auth"`` or ``"open"`` — selects the HPDS backend by
+            URL path.  ``"open"`` posts to ``/hpds/open/query/sync`` (v1);
+            ``"auth"`` posts to ``/hpds/auth/v3/query/sync``.  This
+            preserves the split where BDC's gateway serves open-access
+            traffic only on v1 and authorized traffic on v3.
 
     Returns:
         - ``count``        → :class:`CountResult`
@@ -107,12 +100,8 @@ def run_query(
         PicSureQueryError: If the server response cannot be parsed.
     """
     resolved_type = _resolve_query_type(query_type)
-    body = build_query_body(query, resource_uuid, resolved_type)
-    path = (
-        _PICSURE_QUERY_SYNC_PATH_LEGACY
-        if use_legacy_query_path
-        else _PICSURE_QUERY_SYNC_PATH
-    )
+    body = build_query_body(query, resolved_type)
+    path = query_prefix(backend, v3=backend == "auth") + "/query/sync"
 
     try:
         raw = client.post_raw(path, body=body)
@@ -155,16 +144,19 @@ def run_query(
 
 def build_query_body(
     query: Query | Clause | ClauseGroup,
-    resource_uuid: str,
     expected_result_type: str,
 ) -> dict[str, object]:
-    """Assemble the v3 ``/picsure/v3/query/sync`` request body.
+    """Assemble the ``/hpds/{auth,open}[/v3]/query`` request body.
 
     Normalizes the query into a phenotypic filter tree and a list of
     ``includeConcepts``; the tree becomes ``phenotypicClause`` and the
     concept paths become the top-level ``select`` array.
 
     Notes:
+        No ``resourceUUID`` is sent: the gateway selects the HPDS backend
+        by URL path (``/hpds/auth`` vs ``/hpds/open``), not by a
+        resource-selection UUID in the body.
+
         ``authorizationFilters`` is intentionally omitted from the body.
         PSAMA populates it server-side from the user's token; sending a
         client-asserted list (especially with a long-term token) is
@@ -181,7 +173,6 @@ def build_query_body(
             "picsureId": None,
             "id": None,
         },
-        "resourceUUID": resource_uuid,
     }
 
 

--- a/src/picsure/_services/query_save.py
+++ b/src/picsure/_services/query_save.py
@@ -7,6 +7,7 @@ from picsure._models.clause import Clause
 from picsure._models.clause_group import ClauseGroup
 from picsure._models.query import Query
 from picsure._services._errors import translate_stage_error
+from picsure._services._hpds_paths import query_prefix
 from picsure._services.query_run import build_query_body
 from picsure._transport.errors import TransportError
 from picsure.errors import (
@@ -17,7 +18,9 @@ from picsure.errors import (
 if TYPE_CHECKING:
     from picsure._transport.client import PicSureClient
 
-_QUERY_SUBMIT_PATH = "/picsure/v3/query"
+# The named-dataset collection lives on the operations service, not HPDS; its
+# path is out of scope for the HPDS ingress migration and still resolves via
+# the gateway's legacy catch-all.
 _NAMED_DATASET_COLLECTION_PATH = "/picsure/dataset/named"
 _NAMED_DATASET_ITEM_PATH = "/picsure/dataset/named/{named_dataset_id}"
 
@@ -28,11 +31,10 @@ _NAME_MAX_LEN = 255
 
 def save_query_by_name(
     client: PicSureClient,
-    resource_uuid: str,
     query: Query | Clause | ClauseGroup,
     name: str,
     *,
-    use_legacy_query_path: bool,
+    backend: str,
     overwrite: bool = False,
 ) -> str:
     """Submit a query, then save it to the user's profile under ``name``.
@@ -48,7 +50,7 @@ def save_query_by_name(
     Open-access deployments are not supported: the ``/dataset/named/``
     endpoint requires an authenticated principal.
     """
-    if use_legacy_query_path:
+    if backend == "open":
         raise PicSureValidationError(
             "saveQueryByName is not supported on open-access platforms. "
             "Connect with an authorized platform (e.g. Platform.BDC_AUTHORIZED) "
@@ -63,8 +65,9 @@ def save_query_by_name(
             "Pass overwrite=True to repoint it at the new query."
         )
 
-    body = build_query_body(query, resource_uuid, "COUNT")
-    query_id = _submit_and_extract_id(client, body)
+    body = build_query_body(query, "COUNT")
+    submit_path = query_prefix(backend, v3=True) + "/query"
+    query_id = _submit_and_extract_id(client, submit_path, body)
 
     if existing is None:
         _create_named_dataset(client, query_id=query_id, name=name)
@@ -171,9 +174,11 @@ def _validate_name(name: str) -> None:
         )
 
 
-def _submit_and_extract_id(client: PicSureClient, body: dict[str, object]) -> str:
+def _submit_and_extract_id(
+    client: PicSureClient, submit_path: str, body: dict[str, object]
+) -> str:
     try:
-        response = client.post_json(_QUERY_SUBMIT_PATH, body=body)
+        response = client.post_json(submit_path, body=body)
     except TransportError as exc:
         raise translate_stage_error(
             exc, service="saveQueryByName", stage="submit"

--- a/src/picsure/_transport/client.py
+++ b/src/picsure/_transport/client.py
@@ -71,7 +71,7 @@ class PicSureClient:
     ) -> None:
         # BDC's API gateway routes auth based on a "request-source" header:
         # "Authorized" when a bearer token is present, "Open" otherwise.
-        # Without it, authorized endpoints (e.g. /picsure/v3/query/sync) can
+        # Without it, authorized endpoints (e.g. /hpds/auth/v3/query/sync) can
         # reject tokens that are otherwise valid on PSAMA or the data-dictionary.
         token = token.strip()
         headers = {

--- a/src/picsure/_transport/platforms.py
+++ b/src/picsure/_transport/platforms.py
@@ -11,7 +11,6 @@ class PlatformConfig:
     """Connection details for a known PIC-SURE deployment."""
 
     url: str
-    resource_uuid: str
     label: str
     include_consents: bool
     requires_auth: bool
@@ -23,7 +22,6 @@ class PlatformInfo:
     """Resolved platform connection details."""
 
     url: str
-    resource_uuid: str | None = None
     include_consents: bool = False
     # Default True for custom URLs — safer to assume a token is needed
     # unless the caller explicitly opts out with ``requires_auth=False``.
@@ -34,11 +32,12 @@ class PlatformInfo:
 class Platform(Enum):
     """Known PIC-SURE deployment platforms.
 
-    Each member stores a :class:`PlatformConfig`.  BDC Authorized and
-    BDC Open share a domain and are distinguished by resource UUID.
-    ``include_consents`` controls whether dictionary-api requests must
-    carry the user's consent list; ``requires_auth`` controls whether
-    the connection needs a PIC-SURE token at all.
+    Each member stores a :class:`PlatformConfig`.  BDC Authorized and BDC
+    Open share a domain; they are distinguished by which HPDS the gateway
+    routes to — the ``/hpds/auth`` vs ``/hpds/open`` path — not by a
+    resource UUID.  ``include_consents`` controls whether dictionary-api
+    requests must carry the user's consent list; ``requires_auth``
+    controls whether the connection needs a PIC-SURE token at all.
 
     Pass a member to :func:`picsure.connect` to connect to a known
     platform, or pass a custom URL string for unlisted deployments.
@@ -46,7 +45,6 @@ class Platform(Enum):
 
     BDC_AUTHORIZED = PlatformConfig(
         url="https://picsure.biodatacatalyst.nhlbi.nih.gov",
-        resource_uuid="02e23f52-f354-4e8b-992c-d37c8b9ba140",
         label="BDC Authorized",
         include_consents=True,
         requires_auth=True,
@@ -54,7 +52,6 @@ class Platform(Enum):
     )
     BDC_OPEN = PlatformConfig(
         url="https://picsure.biodatacatalyst.nhlbi.nih.gov",
-        resource_uuid="ac004461-1b47-4832-80e2-22a4aecabe39",
         label="BDC Open",
         include_consents=False,
         requires_auth=False,
@@ -62,7 +59,6 @@ class Platform(Enum):
     )
     BDC_DEV_AUTHORIZED = PlatformConfig(
         url="https://dev.picsure.biodatacatalyst.nhlbi.nih.gov",
-        resource_uuid="02e23f52-f354-4e8b-992c-d37c8b9ba140",
         label="BDC Authorized",
         include_consents=True,
         requires_auth=True,
@@ -70,7 +66,6 @@ class Platform(Enum):
     )
     BDC_DEV_OPEN = PlatformConfig(
         url="https://dev.picsure.biodatacatalyst.nhlbi.nih.gov",
-        resource_uuid="ac004461-1b47-4832-80e2-22a4aecabe39",
         label="BDC Open",
         include_consents=False,
         requires_auth=False,
@@ -78,7 +73,6 @@ class Platform(Enum):
     )
     BDC_PREDEV_AUTHORIZED = PlatformConfig(
         url="https://predev.picsure.biodatacatalyst.nhlbi.nih.gov",
-        resource_uuid="02e23f52-f354-4e8b-992c-d37c8b9ba140",
         label="BDC Authorized",
         include_consents=True,
         requires_auth=True,
@@ -86,7 +80,6 @@ class Platform(Enum):
     )
     BDC_PREDEV_OPEN = PlatformConfig(
         url="https://predev.picsure.biodatacatalyst.nhlbi.nih.gov",
-        resource_uuid="ac004461-1b47-4832-80e2-22a4aecabe39",
         label="BDC Open",
         include_consents=False,
         requires_auth=False,
@@ -94,7 +87,6 @@ class Platform(Enum):
     )
     NHANES_AUTHORIZED = PlatformConfig(
         url="https://nhanes.hms.harvard.edu/",
-        resource_uuid="ded89b08-faa9-435c-b7c4-55b81922ee5f",
         label="Nhanes Authorized",
         include_consents=False,
         requires_auth=True,
@@ -102,7 +94,6 @@ class Platform(Enum):
     )
     NHANES_OPEN = PlatformConfig(
         url="https://nhanes.hms.harvard.edu/",
-        resource_uuid="ded89b08-faa9-435c-b7c4-55b81922ee5f",
         label="Nhanes Open",
         include_consents=False,
         requires_auth=False,
@@ -112,10 +103,6 @@ class Platform(Enum):
     @property
     def url(self) -> str:
         return self.value.url
-
-    @property
-    def resource_uuid(self) -> str:
-        return self.value.resource_uuid
 
     @property
     def label(self) -> str:
@@ -157,8 +144,8 @@ def resolve_platform(
             their own flag.
 
     Returns:
-        A :class:`PlatformInfo` with the base URL, optional resource
-        UUID, consent policy, auth requirement, and genomic support flag.
+        A :class:`PlatformInfo` with the base URL, consent policy, auth
+        requirement, and genomic support flag.
 
     Raises:
         PicSureValidationError: If the value is not a ``Platform`` member
@@ -180,7 +167,6 @@ def resolve_platform(
         )
         return PlatformInfo(
             url=platform.url,
-            resource_uuid=platform.resource_uuid,
             include_consents=resolved_consents,
             requires_auth=resolved_auth,
             supports_genomic=resolved_genomic,

--- a/tests/unit/dev/test_connect_dev.py
+++ b/tests/unit/dev/test_connect_dev.py
@@ -87,7 +87,10 @@ def test_dev_mode_records_connect_event():
     assert len(connect_rows) == 1
     assert connect_rows.iloc[0]["name"] == "connect"
     md = connect_rows.iloc[0]["metadata"]
-    assert md["resources"] == 1
+    # The resource registry was removed, so the connect event no longer
+    # carries a "resources" count; it still records consents + auth.
+    assert "resources" not in md
+    assert md["consents"] == 0
     assert md["requires_auth"] is True
 
 

--- a/tests/unit/dev/test_session_dev.py
+++ b/tests/unit/dev/test_session_dev.py
@@ -54,7 +54,7 @@ def test_dev_clear_is_noop_when_off():
 
 @respx.mock
 def test_runquery_count_emits_http_and_function_events():
-    respx.post(f"{BASE_URL}/picsure/v3/query/sync").mock(
+    respx.post(f"{BASE_URL}/hpds/auth/v3/query/sync").mock(
         return_value=httpx.Response(200, content=b"42")
     )
     session = _make_session(dev_enabled=True)
@@ -75,7 +75,7 @@ def test_runquery_count_emits_http_and_function_events():
 
 @respx.mock
 def test_dev_stats_aggregates_from_live_calls():
-    respx.post(f"{BASE_URL}/picsure/v3/query/sync").mock(
+    respx.post(f"{BASE_URL}/hpds/auth/v3/query/sync").mock(
         return_value=httpx.Response(200, content=b"42")
     )
     session = _make_session(dev_enabled=True)
@@ -96,7 +96,7 @@ def test_dev_stats_aggregates_from_live_calls():
 
 @respx.mock
 def test_dev_clear_empties_buffer():
-    respx.post(f"{BASE_URL}/picsure/v3/query/sync").mock(
+    respx.post(f"{BASE_URL}/hpds/auth/v3/query/sync").mock(
         return_value=httpx.Response(200, content=b"1")
     )
     session = _make_session(dev_enabled=True)

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -10,8 +10,6 @@ import respx
 from picsure._models.session import Session
 from picsure._services.connect import _token_expiration_from_jwt, connect
 from picsure.errors import (
-    PicSureAuthError,
-    PicSureConnectionError,
     PicSureValidationError,
 )
 
@@ -43,137 +41,65 @@ TOKEN = _make_jwt_claims(
     sub="test-user", email="researcher@university.edu", exp=_JWT_EXP
 )
 
-
-def _mock_connect_flow(
-    resources_response: dict,
-    host: str = BASE_URL,
-) -> None:
-    respx.get(f"{host}/picsure/info/resources").mock(
-        return_value=httpx.Response(200, json=resources_response)
-    )
+# connect() no longer discovers resources via /info/resources — the resource
+# registry was removed and the gateway routes by URL path — so a plain
+# authorized connect (token, no consents) makes no HTTP call at all.  The
+# consent fetch is the only connect-time request, and only when consents are
+# requested; the tests that need a request to inspect drive that path.
 
 
 class TestConnectSuccess:
     @respx.mock
-    def test_returns_session(self, resources_response):
-        _mock_connect_flow(resources_response)
+    def test_returns_session(self):
         session = connect(platform=BASE_URL, token=TOKEN)
         assert isinstance(session, Session)
 
     @respx.mock
-    def test_session_has_correct_email(self, resources_response):
-        _mock_connect_flow(resources_response)
+    def test_session_has_correct_email(self):
         session = connect(platform=BASE_URL, token=TOKEN)
         assert session._user_email == "researcher@university.edu"
 
     @respx.mock
-    def test_session_has_resources(self, resources_response):
-        _mock_connect_flow(resources_response)
+    def test_session_has_no_resources(self):
+        # The resource registry is gone: sessions start with no resources.
         session = connect(platform=BASE_URL, token=TOKEN)
-        assert len(session._resources) == 2
-        uuids = {r.uuid for r in session._resources}
-        assert "resource-uuid-aaaa-1111" in uuids
+        assert session._resources == []
 
     @respx.mock
-    def test_custom_url_has_no_resource_uuid(self, resources_response):
-        _mock_connect_flow(resources_response)
+    def test_custom_url_has_no_resource_uuid(self):
         session = connect(platform=BASE_URL, token=TOKEN)
         assert session._resource_uuid is None
 
     @respx.mock
-    def test_prints_success_message(self, resources_response, capsys):
-        _mock_connect_flow(resources_response)
+    def test_makes_no_registry_request(self):
+        # A plain authorized connect performs zero HTTP calls now.
+        connect(platform=BASE_URL, token=TOKEN)
+        assert len(respx.calls) == 0
+
+    @respx.mock
+    def test_prints_success_message(self, capsys):
         connect(platform=BASE_URL, token=TOKEN)
         captured = capsys.readouterr()
         assert "successfully connected" in captured.out.lower()
         assert "researcher@university.edu" in captured.out
 
     @respx.mock
-    def test_prints_token_expiration(self, resources_response, capsys):
-        _mock_connect_flow(resources_response)
+    def test_prints_token_expiration(self, capsys):
         connect(platform=BASE_URL, token=TOKEN)
         captured = capsys.readouterr()
         assert "token expires" in captured.out.lower()
         assert "2026-06-15" in captured.out
 
 
-class TestConnectAuthErrors:
-    @respx.mock
-    def test_401_raises_auth_error(self):
-        # /info/resources is now the first authenticated call, so it owns
-        # the friendly bad-token message the profile call used to surface.
-        respx.get(f"{BASE_URL}/picsure/info/resources").mock(
-            return_value=httpx.Response(401, text="Unauthorized")
-        )
-
-        with pytest.raises(PicSureAuthError) as exc_info:
-            connect(platform=BASE_URL, token=TOKEN)
-
-        msg = str(exc_info.value)
-        assert "invalid or expired" in msg.lower()
-        assert "picsure.connect()" in msg
-
-
-class TestConnectConnectionErrors:
-    @respx.mock
-    def test_network_error_raises_connection_error(self):
-        respx.get(f"{BASE_URL}/picsure/info/resources").mock(
-            side_effect=httpx.ConnectError("Connection refused")
-        )
-
-        with pytest.raises(PicSureConnectionError) as exc_info:
-            connect(platform=BASE_URL, token=TOKEN)
-
-        msg = str(exc_info.value)
-        assert "resources" in msg.lower()
-
-    @respx.mock
-    def test_resource_fetch_failure_raises_connection_error(self):
-        respx.get(f"{BASE_URL}/picsure/info/resources").mock(
-            return_value=httpx.Response(500, text="Internal Server Error")
-        )
-
-        with pytest.raises(PicSureConnectionError) as exc_info:
-            connect(platform=BASE_URL, token=TOKEN)
-
-        msg = str(exc_info.value)
-        assert "resources" in msg.lower()
-
-    @respx.mock
-    def test_null_resources_payload_raises_connection_error(self):
-        respx.get(f"{BASE_URL}/picsure/info/resources").mock(
-            return_value=httpx.Response(
-                200, content=b"null", headers={"content-type": "application/json"}
-            )
-        )
-
-        with pytest.raises(PicSureConnectionError, match="unexpected resources"):
-            connect(platform=BASE_URL, token=TOKEN)
-
-
 class TestConnectResourceUuid:
     @respx.mock
-    def test_explicit_uuid_overrides_platform(self, resources_response):
-        _mock_connect_flow(resources_response)
+    def test_explicit_uuid_is_stored(self):
+        # resource_uuid is retained for backwards compatibility; it is stored
+        # but no longer selects a backend.
         session = connect(
             platform=BASE_URL, token=TOKEN, resource_uuid="my-custom-uuid"
         )
         assert session._resource_uuid == "my-custom-uuid"
-
-    @respx.mock
-    def test_custom_url_no_uuid_prints_resources(self, resources_response, capsys):
-        _mock_connect_flow(resources_response)
-        connect(platform=BASE_URL, token=TOKEN)
-        captured = capsys.readouterr()
-        assert "Available resources" in captured.out
-        assert "setResourceID" in captured.out
-
-    @respx.mock
-    def test_custom_url_with_uuid_no_prompt(self, resources_response, capsys):
-        _mock_connect_flow(resources_response)
-        connect(platform=BASE_URL, token=TOKEN, resource_uuid="resource-uuid-aaaa-1111")
-        captured = capsys.readouterr()
-        assert "Available resources" not in captured.out
 
 
 class TestConnectValidation:
@@ -197,8 +123,7 @@ class TestConnectConsents:
     }
 
     @respx.mock
-    def test_custom_url_skips_consent_fetch_by_default(self, resources_response):
-        _mock_connect_flow(resources_response)
+    def test_custom_url_skips_consent_fetch_by_default(self):
         template_route = respx.get(self._TEMPLATE_URL).mock(
             return_value=httpx.Response(200, json=self._CONSENT_PAYLOAD)
         )
@@ -209,8 +134,7 @@ class TestConnectConsents:
         assert session.consents == []
 
     @respx.mock
-    def test_include_consents_kwarg_fetches_consents(self, resources_response):
-        _mock_connect_flow(resources_response)
+    def test_include_consents_kwarg_fetches_consents(self):
         respx.get(self._TEMPLATE_URL).mock(
             return_value=httpx.Response(200, json=self._CONSENT_PAYLOAD)
         )
@@ -220,11 +144,10 @@ class TestConnectConsents:
         assert session.consents == ["phs000007.c1", "phs001013.c1"]
 
     @respx.mock
-    def test_include_consents_false_override_skips_fetch(self, resources_response):
+    def test_include_consents_false_override_skips_fetch(self):
         from picsure._transport.platforms import Platform
 
         prod_url = Platform.BDC_AUTHORIZED.url
-        _mock_connect_flow(resources_response, host=prod_url)
         template_route = respx.get(f"{prod_url}/psama/user/me/queryTemplate/").mock(
             return_value=httpx.Response(200, json=self._CONSENT_PAYLOAD)
         )
@@ -239,13 +162,8 @@ class TestConnectConsents:
 
 class TestConnectOpenAccess:
     @respx.mock
-    def test_open_platform_connects_anonymously(self, resources_response):
+    def test_open_platform_connects_anonymously(self):
         from picsure._transport.platforms import Platform
-
-        host = Platform.BDC_DEV_OPEN.url
-        respx.get(f"{host}/picsure/info/resources").mock(
-            return_value=httpx.Response(200, json=resources_response)
-        )
 
         session = connect(platform=Platform.BDC_DEV_OPEN)
 
@@ -254,55 +172,16 @@ class TestConnectOpenAccess:
         assert session.consents == []
 
     @respx.mock
-    def test_open_platform_skips_consent_fetch(self, resources_response):
+    def test_open_platform_makes_no_request(self):
         from picsure._transport.platforms import Platform
-
-        host = Platform.BDC_DEV_OPEN.url
-        respx.get(f"{host}/picsure/info/resources").mock(
-            return_value=httpx.Response(200, json=resources_response)
-        )
-        template_route = respx.get(f"{host}/psama/user/me/queryTemplate/").mock(
-            return_value=httpx.Response(200, json={})
-        )
 
         connect(platform=Platform.BDC_DEV_OPEN)
 
-        assert template_route.called is False
+        assert len(respx.calls) == 0
 
     @respx.mock
-    def test_open_platform_resources_401_degrades_to_empty(self):
+    def test_open_platform_success_message(self, capsys):
         from picsure._transport.platforms import Platform
-
-        host = Platform.BDC_DEV_OPEN.url
-        respx.get(f"{host}/picsure/info/resources").mock(
-            return_value=httpx.Response(401)
-        )
-
-        session = connect(platform=Platform.BDC_DEV_OPEN)
-
-        assert session._resources == []
-
-    @respx.mock
-    def test_open_platform_no_auth_header_sent(self, resources_response):
-        from picsure._transport.platforms import Platform
-
-        host = Platform.BDC_DEV_OPEN.url
-        resources_route = respx.get(f"{host}/picsure/info/resources").mock(
-            return_value=httpx.Response(200, json=resources_response)
-        )
-
-        connect(platform=Platform.BDC_DEV_OPEN)
-
-        assert "authorization" not in resources_route.calls[0].request.headers
-
-    @respx.mock
-    def test_open_platform_success_message(self, resources_response, capsys):
-        from picsure._transport.platforms import Platform
-
-        host = Platform.BDC_DEV_OPEN.url
-        respx.get(f"{host}/picsure/info/resources").mock(
-            return_value=httpx.Response(200, json=resources_response)
-        )
 
         connect(platform=Platform.BDC_DEV_OPEN)
 
@@ -311,74 +190,55 @@ class TestConnectOpenAccess:
         assert "token expires" not in out.lower()
 
     @respx.mock
-    def test_requires_auth_false_override_on_custom_url(self, resources_response):
-        respx.get(f"{BASE_URL}/picsure/info/resources").mock(
-            return_value=httpx.Response(200, json=resources_response)
-        )
-
+    def test_requires_auth_false_override_on_custom_url(self):
         session = connect(platform=BASE_URL, requires_auth=False)
 
         assert session._user_email == "anonymous"
 
 
-class TestConnectLegacyQueryPath:
+class TestConnectBackendSelection:
     @respx.mock
-    def test_bdc_open_uses_legacy_query_path(self, resources_response):
-        # BDC's API gateway 401s open-access requests on /picsure/v3/query/sync.
-        # connect() must flip the session over to /picsure/query/sync whenever
-        # neither auth nor consents are required.
+    def test_bdc_open_uses_open_backend(self):
+        # Open-access (no auth, no consents) routes to /hpds/open and the v1
+        # query lifecycle.
         from picsure._transport.platforms import Platform
-
-        host = Platform.BDC_DEV_OPEN.url
-        respx.get(f"{host}/picsure/info/resources").mock(
-            return_value=httpx.Response(200, json=resources_response)
-        )
 
         session = connect(platform=Platform.BDC_DEV_OPEN)
 
-        assert session._use_legacy_query_path is True
+        assert session._backend == "open"
 
     @respx.mock
-    def test_authorized_platform_uses_v3_query_path(self, resources_response):
+    def test_authorized_platform_uses_auth_backend(self):
         from picsure._transport.platforms import Platform
 
         host = Platform.BDC_DEV_AUTHORIZED.url
-        _mock_connect_flow(resources_response, host=host)
         respx.get(f"{host}/psama/user/me/queryTemplate/").mock(
             return_value=httpx.Response(200, json={})
         )
 
         session = connect(platform=Platform.BDC_DEV_AUTHORIZED, token=TOKEN)
 
-        # BDC Authorized requires both auth AND consents; it stays on v3.
-        assert session._use_legacy_query_path is False
+        # BDC Authorized requires both auth AND consents; routes to /hpds/auth.
+        assert session._backend == "auth"
 
     @respx.mock
-    def test_custom_url_default_uses_v3_query_path(self, resources_response):
-        # Custom URLs default to requires_auth=True, so legacy routing
-        # stays off.
-        _mock_connect_flow(resources_response)
-
+    def test_custom_url_default_uses_auth_backend(self):
+        # Custom URLs default to requires_auth=True, so they route to /hpds/auth.
         session = connect(platform=BASE_URL, token=TOKEN)
 
-        assert session._use_legacy_query_path is False
+        assert session._backend == "auth"
 
     @respx.mock
-    def test_custom_url_open_override_uses_legacy_query_path(self, resources_response):
-        # Custom URL with requires_auth=False AND no consents — flag flips on.
-        respx.get(f"{BASE_URL}/picsure/info/resources").mock(
-            return_value=httpx.Response(200, json=resources_response)
-        )
-
+    def test_custom_url_open_override_uses_open_backend(self):
+        # Custom URL with requires_auth=False AND no consents => /hpds/open.
         session = connect(platform=BASE_URL, requires_auth=False)
 
-        assert session._use_legacy_query_path is True
+        assert session._backend == "open"
 
     @respx.mock
-    def test_consents_only_keeps_v3_query_path(self, resources_response):
-        # If the deployment requires consents (even with auth on), it's
-        # an authorized backend — stay on v3.
-        _mock_connect_flow(resources_response)
+    def test_consents_only_keeps_auth_backend(self):
+        # If the deployment requires consents (even with auth on), it's an
+        # authorized backend — routes to /hpds/auth.
         respx.get(f"{BASE_URL}/psama/user/me/queryTemplate/").mock(
             return_value=httpx.Response(200, json={})
         )
@@ -389,19 +249,17 @@ class TestConnectLegacyQueryPath:
             include_consents=True,
         )
 
-        assert session._use_legacy_query_path is False
+        assert session._backend == "auth"
 
 
 class TestConnectSupportsGenomic:
     @respx.mock
-    def test_connect_threads_supports_genomic_override(self, resources_response):
-        _mock_connect_flow(resources_response)
+    def test_connect_threads_supports_genomic_override(self):
         session = connect(platform=BASE_URL, token=TOKEN, supports_genomic=True)
         assert session._supports_genomic is True
 
     @respx.mock
-    def test_connect_supports_genomic_defaults_false(self, resources_response):
-        _mock_connect_flow(resources_response)
+    def test_connect_supports_genomic_defaults_false(self):
         session = connect(platform=BASE_URL, token=TOKEN)
         assert session._supports_genomic is False
 
@@ -462,10 +320,13 @@ class TestEmailFromJwt:
 
 
 class TestConnectCorrelationHeaders:
+    _TEMPLATE_URL = f"{BASE_URL}/psama/user/me/queryTemplate/"
+
     @respx.mock
-    def test_connect_sends_session_id_and_default_client_type(self, resources_response):
-        _mock_connect_flow(resources_response)
-        session = connect(platform=BASE_URL, token=TOKEN)
+    def test_connect_sends_session_id_and_default_client_type(self):
+        # Drive the consent fetch so there is a request to inspect.
+        respx.get(self._TEMPLATE_URL).mock(return_value=httpx.Response(200, json={}))
+        session = connect(platform=BASE_URL, token=TOKEN, include_consents=True)
 
         # session.session_id is a freshly generated uuid4 string.
         assert uuid.UUID(session.session_id)
@@ -477,9 +338,14 @@ class TestConnectCorrelationHeaders:
         assert first_req.headers["user-agent"].startswith("picsure-python-adapter/")
 
     @respx.mock
-    def test_connect_forwards_client_type_override(self, resources_response):
-        _mock_connect_flow(resources_response)
-        session = connect(platform=BASE_URL, token=TOKEN, client_type="R_ADAPTER")
+    def test_connect_forwards_client_type_override(self):
+        respx.get(self._TEMPLATE_URL).mock(return_value=httpx.Response(200, json={}))
+        session = connect(
+            platform=BASE_URL,
+            token=TOKEN,
+            include_consents=True,
+            client_type="R_ADAPTER",
+        )
 
         assert respx.calls[0].request.headers["x-client-type"] == "R_ADAPTER"
         assert (
@@ -491,8 +357,7 @@ class TestConnectCorrelationHeaders:
         assert uuid.UUID(session.session_id)
 
     @respx.mock
-    def test_each_connect_gets_a_distinct_session_id(self, resources_response):
-        _mock_connect_flow(resources_response)
+    def test_each_connect_gets_a_distinct_session_id(self):
         first = connect(platform=BASE_URL, token=TOKEN)
         second = connect(platform=BASE_URL, token=TOKEN)
         assert first.session_id != second.session_id

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -17,12 +17,11 @@ from picsure.errors import (
 
 BASE_URL = "https://test.example.com"
 TOKEN = "test-token"
-RESOURCE_UUID = "resource-uuid-aaaa-1111"
 QUERY_ID = "abc-123"
 
-SUBMIT_URL = f"{BASE_URL}/picsure/v3/query"
-STATUS_URL = f"{BASE_URL}/picsure/v3/query/{QUERY_ID}/status"
-RESULT_URL = f"{BASE_URL}/picsure/v3/query/{QUERY_ID}/result"
+SUBMIT_URL = f"{BASE_URL}/hpds/auth/v3/query"
+STATUS_URL = f"{BASE_URL}/hpds/auth/v3/query/{QUERY_ID}/status"
+RESULT_URL = f"{BASE_URL}/hpds/auth/v3/query/{QUERY_ID}/result"
 
 
 def _make_client() -> PicSureClient:
@@ -56,7 +55,7 @@ class TestExportPFBHappyPath:
 
         output = tmp_path / "out.pfb"
         with patch("picsure._services.export.time.sleep") as sleep_mock:
-            export_pfb(_make_client(), RESOURCE_UUID, _simple_clause(), output)
+            export_pfb(_make_client(), _simple_clause(), output, backend="auth")
 
         assert output.exists()
         assert output.read_bytes() == b"pfb_content"
@@ -79,14 +78,14 @@ class TestExportPFBHappyPath:
 
         output = tmp_path / "out.pfb"
         with patch("picsure._services.export.time.sleep") as sleep_mock:
-            export_pfb(_make_client(), RESOURCE_UUID, _simple_clause(), output)
+            export_pfb(_make_client(), _simple_clause(), output, backend="auth")
 
         assert output.exists()
         assert output.read_bytes() == b"pfb_content"
         sleep_mock.assert_called_once_with(1.0)
 
     @respx.mock
-    def test_sends_pfb_result_type_and_resource_uuid(self, tmp_path):
+    def test_sends_pfb_result_type(self, tmp_path):
         import json
 
         submit_route = respx.post(SUBMIT_URL).mock(return_value=_submit_ok())
@@ -96,14 +95,13 @@ class TestExportPFBHappyPath:
         with patch("picsure._services.export.time.sleep"):
             export_pfb(
                 _make_client(),
-                RESOURCE_UUID,
                 _simple_clause(),
                 tmp_path / "out.pfb",
+                backend="auth",
             )
 
         body = json.loads(submit_route.calls[0].request.content)
         assert body["query"]["expectedResultType"] == "DATAFRAME_PFB"
-        assert body["resourceUUID"] == RESOURCE_UUID
         # The filter variable is returned as a PFB column without being
         # repeated in includeConcepts.
         assert body["query"]["select"] == ["\\phs1\\sex\\"]
@@ -130,9 +128,9 @@ class TestExportPFBBackoff:
         with patch("picsure._services.export.time.sleep") as sleep_mock:
             export_pfb(
                 _make_client(),
-                RESOURCE_UUID,
                 _simple_clause(),
                 tmp_path / "out.pfb",
+                backend="auth",
             )
 
         intervals = [call.args[0] for call in sleep_mock.call_args_list]
@@ -155,9 +153,9 @@ class TestExportPFBBackoff:
         ):
             export_pfb(
                 _make_client(),
-                RESOURCE_UUID,
                 _simple_clause(),
                 tmp_path / "out.pfb",
+                backend="auth",
             )
 
         intervals = [call.args[0] for call in sleep_mock.call_args_list]
@@ -177,7 +175,7 @@ class TestExportPFBErrorStatus:
             patch("picsure._services.export.time.sleep"),
             pytest.raises(PicSureQueryError, match="status=ERROR"),
         ):
-            export_pfb(_make_client(), RESOURCE_UUID, _simple_clause(), output)
+            export_pfb(_make_client(), _simple_clause(), output, backend="auth")
 
         assert not output.exists()
         assert not (tmp_path / "out.pfb.part").exists()
@@ -210,9 +208,9 @@ class TestExportPFBTimeout:
         ):
             export_pfb(
                 _make_client(),
-                RESOURCE_UUID,
                 _simple_clause(),
                 tmp_path / "out.pfb",
+                backend="auth",
             )
 
         assert not (tmp_path / "out.pfb").exists()
@@ -228,7 +226,7 @@ class TestExportPFB4xx:
 
         output = tmp_path / "out.pfb"
         with pytest.raises(PicSureValidationError):
-            export_pfb(_make_client(), RESOURCE_UUID, _simple_clause(), output)
+            export_pfb(_make_client(), _simple_clause(), output, backend="auth")
 
         assert not output.exists()
         assert not (tmp_path / "out.pfb.part").exists()
@@ -243,7 +241,7 @@ class TestExportPFB4xx:
             patch("picsure._services.export.time.sleep"),
             pytest.raises(PicSureQueryError),
         ):
-            export_pfb(_make_client(), RESOURCE_UUID, _simple_clause(), output)
+            export_pfb(_make_client(), _simple_clause(), output, backend="auth")
 
         assert not output.exists()
         assert not (tmp_path / "out.pfb.part").exists()
@@ -261,7 +259,7 @@ class TestExportPFB4xx:
             patch("picsure._services.export.time.sleep"),
             pytest.raises(PicSureValidationError),
         ):
-            export_pfb(_make_client(), RESOURCE_UUID, _simple_clause(), output)
+            export_pfb(_make_client(), _simple_clause(), output, backend="auth")
 
         assert not output.exists()
         assert not (tmp_path / "out.pfb.part").exists()
@@ -272,7 +270,7 @@ class TestExportPFB4xx:
 
         output = tmp_path / "out.pfb"
         with pytest.raises(PicSureConnectionError):
-            export_pfb(_make_client(), RESOURCE_UUID, _simple_clause(), output)
+            export_pfb(_make_client(), _simple_clause(), output, backend="auth")
 
         assert not output.exists()
 
@@ -298,7 +296,7 @@ class TestExportPFBAtomicWrite:
             ),
             pytest.raises(PicSureConnectionError, match="out.pfb"),
         ):
-            export_pfb(_make_client(), RESOURCE_UUID, _simple_clause(), output)
+            export_pfb(_make_client(), _simple_clause(), output, backend="auth")
 
         # Neither the final file nor the .part file should remain.
         assert not output.exists()
@@ -325,7 +323,7 @@ class TestExportPFBAtomicWrite:
             patch("picsure._services.export._stream_to_file", side_effect=boom),
             pytest.raises(PicSureConnectionError, match="out.pfb"),
         ):
-            export_pfb(_make_client(), RESOURCE_UUID, _simple_clause(), output)
+            export_pfb(_make_client(), _simple_clause(), output, backend="auth")
 
         assert not output.exists()
         assert not part.exists()

--- a/tests/unit/test_genomic_search.py
+++ b/tests/unit/test_genomic_search.py
@@ -20,7 +20,7 @@ def test_builds_path_with_encoded_params():
         client, "Gene_with_variant", backend="auth", query="BRCA", page=1, size=50
     )
     assert client.last_path == (
-        "/hpds/auth/search/00000000-0000-0000-0000-000000000000/values/"
+        "/hpds/auth/search/values"
         "?genomicConceptPath=Gene_with_variant&query=BRCA&page=1&size=50"
     )
 

--- a/tests/unit/test_genomic_search.py
+++ b/tests/unit/test_genomic_search.py
@@ -17,24 +17,26 @@ class _FakeClient:
 def test_builds_path_with_encoded_params():
     client = _FakeClient({"results": ["BRCA1", "BRCA2"], "page": 1, "total": 2})
     search_genomic_values(
-        client, "RID", "Gene_with_variant", query="BRCA", page=1, size=50
+        client, "Gene_with_variant", backend="auth", query="BRCA", page=1, size=50
     )
     assert client.last_path == (
-        "/picsure/search/RID/values/"
+        "/hpds/auth/search/00000000-0000-0000-0000-000000000000/values/"
         "?genomicConceptPath=Gene_with_variant&query=BRCA&page=1&size=50"
     )
 
 
 def test_returns_value_dataframe():
     client = _FakeClient({"results": ["BRCA1", "BRCA2"], "page": 1, "total": 2})
-    df = search_genomic_values(client, "RID", "Gene_with_variant")
+    df = search_genomic_values(client, "Gene_with_variant", backend="auth")
     assert list(df.columns) == ["value"]
     assert df["value"].tolist() == ["BRCA1", "BRCA2"]
 
 
 def test_preserves_pagination_metadata_in_attrs():
     client = _FakeClient({"results": ["BRCA1"], "page": 2, "total": 41719})
-    df = search_genomic_values(client, "RID", "Gene_with_variant", page=2, size=20)
+    df = search_genomic_values(
+        client, "Gene_with_variant", backend="auth", page=2, size=20
+    )
     assert df.attrs["total"] == 41719
     assert df.attrs["page"] == 2
     assert df.attrs["size"] == 20
@@ -44,10 +46,10 @@ def test_preserves_pagination_metadata_in_attrs():
 def test_malformed_response_raises():
     client = _FakeClient({"unexpected": True})
     with pytest.raises(PicSureQueryError, match="results"):
-        search_genomic_values(client, "RID", "Gene_with_variant")
+        search_genomic_values(client, "Gene_with_variant", backend="auth")
 
 
 def test_blank_key_raises():
     client = _FakeClient({"results": []})
     with pytest.raises(PicSureValidationError, match="non-empty"):
-        search_genomic_values(client, "RID", "   ")
+        search_genomic_values(client, "   ", backend="auth")

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -8,9 +8,6 @@ class TestPlatformEnum:
     def test_bdc_authorized_and_open_share_domain(self):
         assert Platform.BDC_AUTHORIZED.url == Platform.BDC_OPEN.url
 
-    def test_bdc_authorized_and_open_differ_by_uuid(self):
-        assert Platform.BDC_AUTHORIZED.resource_uuid != Platform.BDC_OPEN.resource_uuid
-
     def test_authorized_platforms_include_consents(self):
         assert Platform.BDC_AUTHORIZED.include_consents is True
         assert Platform.BDC_DEV_AUTHORIZED.include_consents is True
@@ -39,7 +36,6 @@ class TestResolvePlatform:
         info = resolve_platform(Platform.BDC_AUTHORIZED)
         assert isinstance(info, PlatformInfo)
         assert info.url == Platform.BDC_AUTHORIZED.url
-        assert info.resource_uuid == Platform.BDC_AUTHORIZED.resource_uuid
 
     def test_known_platform_propagates_include_consents(self):
         assert resolve_platform(Platform.BDC_AUTHORIZED).include_consents is True
@@ -49,16 +45,14 @@ class TestResolvePlatform:
         info = resolve_platform(Platform.BDC_OPEN, include_consents=True)
         assert info.include_consents is True
 
-    def test_bdc_open_returns_same_url_different_uuid(self):
+    def test_bdc_open_resolves_to_same_url(self):
         auth = resolve_platform(Platform.BDC_AUTHORIZED)
         open_ = resolve_platform(Platform.BDC_OPEN)
         assert auth.url == open_.url
-        assert auth.resource_uuid != open_.resource_uuid
 
     def test_custom_url_returned_as_is(self):
         info = resolve_platform("https://my-picsure.example.com")
         assert info.url == "https://my-picsure.example.com"
-        assert info.resource_uuid is None
 
     def test_custom_url_defaults_to_no_consents(self):
         info = resolve_platform("https://my-picsure.example.com")
@@ -107,7 +101,6 @@ class TestResolvePlatform:
     def test_nhanes_open_resolves(self):
         info = resolve_platform(Platform.NHANES_OPEN)
         assert info.url.startswith("https://")
-        assert info.resource_uuid is not None
 
 
 def test_authorized_platforms_support_genomic():

--- a/tests/unit/test_query_load.py
+++ b/tests/unit/test_query_load.py
@@ -243,8 +243,8 @@ from picsure.errors import PicSureAuthError, PicSureConnectionError
 BASE_URL = "https://test.example.com"
 TOKEN = "test-token"
 QUERY_ID = "11111111-2222-3333-4444-555555555555"
-META_URL = f"{BASE_URL}/picsure/query/{QUERY_ID}/metadata"
-V3_META_URL = f"{BASE_URL}/picsure/v3/query/{QUERY_ID}/metadata"
+META_URL = f"{BASE_URL}/hpds/auth/query/{QUERY_ID}/metadata"
+V3_META_URL = f"{BASE_URL}/hpds/auth/v3/query/{QUERY_ID}/metadata"
 
 
 def _make_client() -> PicSureClient:
@@ -302,7 +302,7 @@ class TestLoadQueryHappyPath:
             }
         )
         respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
-        result = load_query(_make_client(), QUERY_ID)
+        result = load_query(_make_client(), QUERY_ID, backend="auth")
         assert isinstance(result, Clause)
         assert result.type == PhenotypicFilterType.FILTER
 
@@ -319,7 +319,7 @@ class TestLoadQueryHappyPath:
             }
         )
         respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
-        result = load_query(_make_client(), QUERY_ID)
+        result = load_query(_make_client(), QUERY_ID, backend="auth")
         assert isinstance(result, Query)
         assert result.includeConcepts == ("\\phs1\\out\\",)
 
@@ -344,15 +344,15 @@ class TestLoadQueryHappyPath:
             inner_query_as_string=True,
         )
         respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
-        result = load_query(_make_client(), QUERY_ID)
+        result = load_query(_make_client(), QUERY_ID, backend="auth")
         assert isinstance(result, Query)
         assert result.includeConcepts == ("\\phs1\\out\\",)
 
     @respx.mock
-    def test_always_uses_legacy_path(self):
-        # The v3 metadata endpoint is broken on BDC; loadQueryByID pins
-        # reads to the legacy path for every deployment, regardless of
-        # how the session was connected.
+    def test_always_uses_non_versioned_path(self):
+        # Query metadata is version-agnostic in the query-service; loadQueryByID
+        # pins reads to the non-versioned metadata route for every deployment,
+        # regardless of how the session was connected.
         body = _envelope(
             {
                 "select": [],
@@ -363,10 +363,12 @@ class TestLoadQueryHappyPath:
                 "id": None,
             }
         )
-        legacy = respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
+        non_versioned = respx.get(META_URL).mock(
+            return_value=httpx.Response(200, json=body)
+        )
         v3 = respx.get(V3_META_URL).mock(return_value=httpx.Response(200, json=body))
-        load_query(_make_client(), QUERY_ID)
-        assert legacy.called
+        load_query(_make_client(), QUERY_ID, backend="auth")
+        assert non_versioned.called
         assert not v3.called
 
 
@@ -390,7 +392,7 @@ class TestLoadQueryStrictness:
         )
         respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
         with pytest.raises(PicSureValidationError, match="NOT"):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")
 
     @respx.mock
     def test_malformed_genomic_filter_missing_key_raises(self):
@@ -406,7 +408,7 @@ class TestLoadQueryStrictness:
         )
         respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
         with pytest.raises(PicSureQueryError, match="key"):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")
 
 
 class TestLoadQueryGenomic:
@@ -425,7 +427,7 @@ class TestLoadQueryGenomic:
             }
         )
         respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
-        result = load_query(_make_client(), QUERY_ID)
+        result = load_query(_make_client(), QUERY_ID, backend="auth")
         assert isinstance(result, Query)
         assert result.phenotypicFilter is None
         assert result.genomicFilters == (
@@ -451,7 +453,7 @@ class TestLoadQueryGenomic:
         )
         respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
         with pytest.raises(PicSureValidationError, match="numeric range"):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")
 
     @respx.mock
     def test_filter_with_any_min_max_rejected(self):
@@ -471,7 +473,7 @@ class TestLoadQueryGenomic:
         )
         respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
         with pytest.raises(PicSureValidationError, match="numeric range"):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")
 
     @respx.mock
     def test_rejects_variant_spec_genomic_filter(self):
@@ -491,31 +493,31 @@ class TestLoadQueryGenomic:
         )
         respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
         with pytest.raises(PicSureValidationError, match="SNP"):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")
 
 
 class TestLoadQueryErrors:
     def test_blank_id_raises_before_http(self):
         with pytest.raises(PicSureValidationError, match="query ID"):
-            load_query(_make_client(), "   ")
+            load_query(_make_client(), "   ", backend="auth")
 
     @respx.mock
     def test_404_raises_validation_with_friendly_message(self):
         respx.get(META_URL).mock(return_value=httpx.Response(404, text="not found"))
         with pytest.raises(PicSureValidationError, match="No saved query found"):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")
 
     @respx.mock
     def test_401_raises_auth_error(self):
         respx.get(META_URL).mock(return_value=httpx.Response(401, text="unauthorized"))
         with pytest.raises(PicSureAuthError):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")
 
     @respx.mock
     def test_5xx_raises_connection_error(self):
         respx.get(META_URL).mock(return_value=httpx.Response(503, text="oops"))
         with pytest.raises(PicSureConnectionError):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")
 
     @respx.mock
     def test_missing_result_metadata_raises_query_error(self):
@@ -523,7 +525,7 @@ class TestLoadQueryErrors:
             return_value=httpx.Response(200, json={"status": "COMPLETED"})
         )
         with pytest.raises(PicSureQueryError, match="resultMetadata"):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")
 
     @respx.mock
     def test_missing_query_json_raises_query_error(self):
@@ -531,7 +533,7 @@ class TestLoadQueryErrors:
             return_value=httpx.Response(200, json={"resultMetadata": {}})
         )
         with pytest.raises(PicSureQueryError, match="queryJson"):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")
 
     @respx.mock
     def test_missing_inner_query_raises_query_error(self):
@@ -542,7 +544,7 @@ class TestLoadQueryErrors:
         }
         respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
         with pytest.raises(PicSureQueryError, match="query"):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")
 
     @respx.mock
     def test_empty_select_and_null_phenotypic_raises_query_error(self):
@@ -558,7 +560,7 @@ class TestLoadQueryErrors:
         )
         respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
         with pytest.raises(PicSureQueryError, match="empty"):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")
 
     @respx.mock
     def test_inner_query_string_with_invalid_json_raises_query_error(self):
@@ -574,4 +576,4 @@ class TestLoadQueryErrors:
         }
         respx.get(META_URL).mock(return_value=httpx.Response(200, json=body))
         with pytest.raises(PicSureQueryError, match="JSON"):
-            load_query(_make_client(), QUERY_ID)
+            load_query(_make_client(), QUERY_ID, backend="auth")

--- a/tests/unit/test_query_run.py
+++ b/tests/unit/test_query_run.py
@@ -20,8 +20,8 @@ from picsure.errors import (
 BASE_URL = "https://test.example.com"
 TOKEN = "test-token"
 RESOURCE_UUID = "resource-uuid-aaaa-1111"
-QUERY_URL = f"{BASE_URL}/picsure/v3/query/sync"
-LEGACY_QUERY_URL = f"{BASE_URL}/picsure/query/sync"
+QUERY_URL = f"{BASE_URL}/hpds/auth/v3/query/sync"
+OPEN_QUERY_URL = f"{BASE_URL}/hpds/open/query/sync"
 
 
 def _make_client() -> PicSureClient:
@@ -39,7 +39,7 @@ class TestRunQueryCount:
     def test_returns_count_result(self):
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=b"1234"))
         client = _make_client()
-        result = run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+        result = run_query(client, _simple_clause(), "count", backend="auth")
         assert isinstance(result, CountResult)
         assert result.value == 1234
         assert result.margin is None
@@ -53,12 +53,14 @@ class TestRunQueryCount:
             return_value=httpx.Response(200, content=b"42")
         )
         client = _make_client()
-        run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+        run_query(client, _simple_clause(), "count", backend="auth")
 
         import json
 
         body = json.loads(route.calls[0].request.content)
-        assert body["resourceUUID"] == RESOURCE_UUID
+        # The gateway selects the HPDS backend by URL path, so the body
+        # must not carry a top-level resourceUUID sibling anymore.
+        assert "resourceUUID" not in body
         query = body["query"]
         assert query["expectedResultType"] == "COUNT"
         # The clause's own concept path is folded into ``select`` so a
@@ -83,7 +85,7 @@ class TestRunQueryCount:
             return_value=httpx.Response(200, content=b"7")
         )
         client = _make_client()
-        run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+        run_query(client, _simple_clause(), "count", backend="auth")
 
         import json
 
@@ -97,7 +99,7 @@ class TestRunQueryCount:
         )
         client = _make_client()
         with pytest.raises(PicSureQueryError, match="Expected a count"):
-            run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+            run_query(client, _simple_clause(), "count", backend="auth")
 
     @respx.mock
     def test_count_strips_surrounding_whitespace(self):
@@ -105,7 +107,7 @@ class TestRunQueryCount:
             return_value=httpx.Response(200, content=b"  567  \n")
         )
         client = _make_client()
-        result = run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+        result = run_query(client, _simple_clause(), "count", backend="auth")
         assert result.value == 567
         assert result.obfuscated is False
 
@@ -115,7 +117,7 @@ class TestRunQueryCount:
             return_value=httpx.Response(200, content="11309 \u00b13".encode())
         )
         client = _make_client()
-        result = run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+        result = run_query(client, _simple_clause(), "count", backend="auth")
         assert result.value == 11309
         assert result.margin == 3
         assert result.cap is None
@@ -125,7 +127,7 @@ class TestRunQueryCount:
     def test_suppressed_count_has_cap_and_null_value(self):
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=b"< 10"))
         client = _make_client()
-        result = run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+        result = run_query(client, _simple_clause(), "count", backend="auth")
         assert result.value is None
         assert result.margin is None
         assert result.cap == 10
@@ -138,14 +140,14 @@ class TestRunQueryCount:
         )
         client = _make_client()
         with pytest.raises(PicSureQueryError, match="Expected a count"):
-            run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+            run_query(client, _simple_clause(), "count", backend="auth")
 
     @respx.mock
     def test_empty_response_raises(self):
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=b""))
         client = _make_client()
         with pytest.raises(PicSureQueryError, match="Expected a count"):
-            run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+            run_query(client, _simple_clause(), "count", backend="auth")
 
 
 class TestRunQueryParticipant:
@@ -155,7 +157,7 @@ class TestRunQueryParticipant:
             return_value=httpx.Response(200, content=participant_response)
         )
         client = _make_client()
-        df = run_query(client, RESOURCE_UUID, _simple_clause(), "participant")
+        df = run_query(client, _simple_clause(), "participant", backend="auth")
         assert len(df) == 5
         assert "patient_id" in df.columns
         assert "sex" in df.columns
@@ -166,7 +168,7 @@ class TestRunQueryParticipant:
             return_value=httpx.Response(200, content=b"id\n1\n")
         )
         client = _make_client()
-        run_query(client, RESOURCE_UUID, _simple_clause(), "participant")
+        run_query(client, _simple_clause(), "participant", backend="auth")
 
         import json
 
@@ -177,7 +179,7 @@ class TestRunQueryParticipant:
     def test_empty_csv_returns_empty_dataframe(self):
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=b""))
         client = _make_client()
-        df = run_query(client, RESOURCE_UUID, _simple_clause(), "participant")
+        df = run_query(client, _simple_clause(), "participant", backend="auth")
         assert len(df) == 0
 
 
@@ -188,7 +190,7 @@ class TestRunQueryTimestamp:
             return_value=httpx.Response(200, content=b"id,date,val\n1,2024-01-01,120\n")
         )
         client = _make_client()
-        run_query(client, RESOURCE_UUID, _simple_clause(), "timestamp")
+        run_query(client, _simple_clause(), "timestamp", backend="auth")
 
         import json
 
@@ -200,7 +202,7 @@ class TestRunQueryTimestamp:
         csv = b"patient_id,variable,date,value\nP001,bp,2024-01-15,120\n"
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=csv))
         client = _make_client()
-        df = run_query(client, RESOURCE_UUID, _simple_clause(), "timestamp")
+        df = run_query(client, _simple_clause(), "timestamp", backend="auth")
         assert len(df) == 1
         assert "date" in df.columns
 
@@ -215,7 +217,7 @@ class TestRunQueryParticipantMalformed:
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=body))
         client = _make_client()
         with pytest.raises(PicSureQueryError, match="malformed CSV"):
-            run_query(client, RESOURCE_UUID, _simple_clause(), "participant")
+            run_query(client, _simple_clause(), "participant", backend="auth")
 
     @respx.mock
     def test_malformed_csv_error_includes_preview(self):
@@ -225,7 +227,7 @@ class TestRunQueryParticipantMalformed:
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=body))
         client = _make_client()
         with pytest.raises(PicSureQueryError) as excinfo:
-            run_query(client, RESOURCE_UUID, _simple_clause(), "participant")
+            run_query(client, _simple_clause(), "participant", backend="auth")
         assert "a,b,c" in str(excinfo.value)
 
     @respx.mock
@@ -236,7 +238,7 @@ class TestRunQueryParticipantMalformed:
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=body))
         client = _make_client()
         with pytest.raises(PicSureQueryError, match="malformed CSV"):
-            run_query(client, RESOURCE_UUID, _simple_clause(), "participant")
+            run_query(client, _simple_clause(), "participant", backend="auth")
 
     @respx.mock
     def test_empty_response_still_returns_empty_dataframe(self):
@@ -244,14 +246,14 @@ class TestRunQueryParticipantMalformed:
         # not a parse error.
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=b""))
         client = _make_client()
-        df = run_query(client, RESOURCE_UUID, _simple_clause(), "participant")
+        df = run_query(client, _simple_clause(), "participant", backend="auth")
         assert len(df) == 0
 
     @respx.mock
     def test_whitespace_only_response_returns_empty_dataframe(self):
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=b"   \n"))
         client = _make_client()
-        df = run_query(client, RESOURCE_UUID, _simple_clause(), "participant")
+        df = run_query(client, _simple_clause(), "participant", backend="auth")
         assert len(df) == 0
 
 
@@ -262,7 +264,7 @@ class TestRunQueryCrossCount:
             return_value=httpx.Response(200, content=b'{"\\\\phs000001\\\\": "42"}')
         )
         client = _make_client()
-        run_query(client, RESOURCE_UUID, _simple_clause(), "cross_count")
+        run_query(client, _simple_clause(), "cross_count", backend="auth")
 
         import json
 
@@ -277,7 +279,7 @@ class TestRunQueryCrossCount:
         route = respx.post(QUERY_URL).mock(
             return_value=httpx.Response(200, content=b'{"\\\\phs1\\\\sex\\\\": "42"}')
         )
-        run_query(_make_client(), RESOURCE_UUID, _simple_clause(), "cross_count")
+        run_query(_make_client(), _simple_clause(), "cross_count", backend="auth")
 
         import json
 
@@ -295,7 +297,7 @@ class TestRunQueryCrossCount:
         ).encode()
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=payload))
         client = _make_client()
-        result = run_query(client, RESOURCE_UUID, _simple_clause(), "cross_count")
+        result = run_query(client, _simple_clause(), "cross_count", backend="auth")
 
         assert isinstance(result, dict)
         assert set(result.keys()) == {
@@ -323,14 +325,14 @@ class TestRunQueryCrossCount:
         )
         client = _make_client()
         with pytest.raises(PicSureQueryError, match="cross-count"):
-            run_query(client, RESOURCE_UUID, _simple_clause(), "cross_count")
+            run_query(client, _simple_clause(), "cross_count", backend="auth")
 
     @respx.mock
     def test_non_object_json_raises(self):
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=b"[1,2,3]"))
         client = _make_client()
         with pytest.raises(PicSureQueryError, match="cross-count"):
-            run_query(client, RESOURCE_UUID, _simple_clause(), "cross_count")
+            run_query(client, _simple_clause(), "cross_count", backend="auth")
 
     @respx.mock
     def test_invalid_count_value_raises(self):
@@ -339,7 +341,7 @@ class TestRunQueryCrossCount:
         )
         client = _make_client()
         with pytest.raises(PicSureQueryError, match="Expected a count"):
-            run_query(client, RESOURCE_UUID, _simple_clause(), "cross_count")
+            run_query(client, _simple_clause(), "cross_count", backend="auth")
 
     @respx.mock
     def test_integer_values_direct_hpds_shape(self):
@@ -349,7 +351,7 @@ class TestRunQueryCrossCount:
         payload = b'{"\\\\phs000007\\\\": 42, "\\\\phs000013\\\\": 100}'
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=payload))
         client = _make_client()
-        result = run_query(client, RESOURCE_UUID, _simple_clause(), "cross_count")
+        result = run_query(client, _simple_clause(), "cross_count", backend="auth")
 
         assert isinstance(result, dict)
         assert set(result.keys()) == {"\\phs000007\\", "\\phs000013\\"}
@@ -375,7 +377,7 @@ class TestRunQueryCrossCount:
         ).encode()
         respx.post(QUERY_URL).mock(return_value=httpx.Response(200, content=payload))
         client = _make_client()
-        result = run_query(client, RESOURCE_UUID, _simple_clause(), "cross_count")
+        result = run_query(client, _simple_clause(), "cross_count", backend="auth")
 
         assert result["\\a\\"].value == 42
         assert result["\\a\\"].obfuscated is False
@@ -396,7 +398,7 @@ class TestRunQueryCrossCount:
         )
         client = _make_client()
         with pytest.raises(PicSureQueryError, match="Expected a count"):
-            run_query(client, RESOURCE_UUID, _simple_clause(), "cross_count")
+            run_query(client, _simple_clause(), "cross_count", backend="auth")
 
 
 class TestRunQueryWithClauseGroup:
@@ -411,7 +413,7 @@ class TestRunQueryWithClauseGroup:
             operator=GroupOperator.AND,
         )
         client = _make_client()
-        run_query(client, RESOURCE_UUID, group, "count")
+        run_query(client, group, "count", backend="auth")
 
         import json
 
@@ -435,7 +437,7 @@ class TestRunQueryWithClauseGroup:
             includeConcepts=("\\out_a\\", "\\out_b\\"),
         )
         client = _make_client()
-        run_query(client, RESOURCE_UUID, query, "count")
+        run_query(client, query, "count", backend="auth")
 
         import json
 
@@ -452,7 +454,7 @@ class TestRunQueryWithClauseGroup:
         )
         query = Query(includeConcepts=("\\a\\", "\\b\\"))
         client = _make_client()
-        run_query(client, RESOURCE_UUID, query, "count")
+        run_query(client, query, "count", backend="auth")
 
         import json
 
@@ -469,7 +471,7 @@ class TestRunQueryWithClauseGroup:
             return_value=httpx.Response(200, content=b"100")
         )
         client = _make_client()
-        run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+        run_query(client, _simple_clause(), "count", backend="auth")
 
         import json
 
@@ -485,7 +487,7 @@ class TestSelectIncludesFilterConcepts:
         route = respx.post(QUERY_URL).mock(
             return_value=httpx.Response(200, content=b"1")
         )
-        run_query(_make_client(), RESOURCE_UUID, query, "participant")
+        run_query(_make_client(), query, "participant", backend="auth")
 
         import json
 
@@ -551,7 +553,7 @@ class TestRunQueryValidation:
     def test_invalid_query_type_raises(self):
         client = _make_client()
         with pytest.raises(PicSureValidationError, match="not a valid query type"):
-            run_query(client, RESOURCE_UUID, _simple_clause(), "invalid")
+            run_query(client, _simple_clause(), "invalid", backend="auth")
 
     def test_plain_dict_query_raises_validation_error(self):
         # A plain dict is not a Clause or ClauseGroup. We want an
@@ -564,9 +566,9 @@ class TestRunQueryValidation:
         ):
             run_query(
                 client,
-                RESOURCE_UUID,
                 {"keys": ["\\phs1\\sex\\"]},  # type: ignore[arg-type]
                 "count",
+                backend="auth",
             )
 
 
@@ -578,14 +580,14 @@ class TestRunQueryErrors:
         )
         client = _make_client()
         with pytest.raises(PicSureConnectionError, match="query"):
-            run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+            run_query(client, _simple_clause(), "count", backend="auth")
 
     @respx.mock
     def test_network_error_raises_connection_error(self):
         respx.post(QUERY_URL).mock(side_effect=httpx.ConnectError("Connection refused"))
         client = _make_client()
         with pytest.raises(PicSureConnectionError):
-            run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+            run_query(client, _simple_clause(), "count", backend="auth")
 
 
 class TestQueryTypeMemberInput:
@@ -632,9 +634,9 @@ class TestRunQueryWithQueryTypeMember:
         client = _make_client()
         result = run_query(
             client,
-            RESOURCE_UUID,
             _simple_clause(),
             QueryType.COUNT,
+            backend="auth",
         )
 
         assert isinstance(result, CountResult)
@@ -672,70 +674,58 @@ class TestSessionRunQueryWithMember:
         assert result.value == 7
 
 
-class TestRunQueryLegacyPath:
+class TestRunQueryBackendRouting:
     @respx.mock
-    def test_default_uses_v3_path(self):
-        v3 = respx.post(QUERY_URL).mock(
+    def test_auth_backend_uses_auth_v3_path(self):
+        auth = respx.post(QUERY_URL).mock(
             return_value=httpx.Response(200, content=b"1"),
         )
-        legacy = respx.post(LEGACY_QUERY_URL).mock(
+        open_route = respx.post(OPEN_QUERY_URL).mock(
             return_value=httpx.Response(200, content=b"99"),
         )
         client = _make_client()
 
-        result = run_query(client, RESOURCE_UUID, _simple_clause(), "count")
+        result = run_query(client, _simple_clause(), "count", backend="auth")
 
         assert isinstance(result, CountResult)
         assert result.value == 1
-        assert v3.call_count == 1
-        assert legacy.call_count == 0
+        assert auth.call_count == 1
+        assert open_route.call_count == 0
 
     @respx.mock
-    def test_flag_routes_to_legacy_path(self):
-        # BDC's API gateway 401s open-access requests on the v3 sync
-        # endpoint.  Open-only deployments must use the legacy path.
-        v3 = respx.post(QUERY_URL).mock(
+    def test_open_backend_routes_to_open_path(self):
+        # BDC's API gateway 401s open-access requests on the auth v3 sync
+        # endpoint.  Open-only deployments must use the open path.
+        auth = respx.post(QUERY_URL).mock(
             return_value=httpx.Response(401, text="Unauthorized"),
         )
-        legacy = respx.post(LEGACY_QUERY_URL).mock(
+        open_route = respx.post(OPEN_QUERY_URL).mock(
             return_value=httpx.Response(200, content=b"42"),
         )
         client = _make_client()
 
-        result = run_query(
-            client,
-            RESOURCE_UUID,
-            _simple_clause(),
-            "count",
-            use_legacy_query_path=True,
-        )
+        result = run_query(client, _simple_clause(), "count", backend="open")
 
         assert isinstance(result, CountResult)
         assert result.value == 42
-        assert v3.call_count == 0
-        assert legacy.call_count == 1
+        assert auth.call_count == 0
+        assert open_route.call_count == 1
 
     @respx.mock
-    def test_legacy_path_preserves_body_shape(self):
-        # The legacy endpoint accepts the same v3-shaped body; we should
+    def test_open_path_preserves_body_shape(self):
+        # The open endpoint accepts the same body shape as auth; we should
         # not start emitting a different shape just because we're routing
-        # to /picsure/query/sync.
-        route = respx.post(LEGACY_QUERY_URL).mock(
+        # to /hpds/open/query/sync.
+        route = respx.post(OPEN_QUERY_URL).mock(
             return_value=httpx.Response(200, content=b"7"),
         )
         client = _make_client()
-        run_query(
-            client,
-            RESOURCE_UUID,
-            _simple_clause(),
-            "count",
-            use_legacy_query_path=True,
-        )
+        run_query(client, _simple_clause(), "count", backend="open")
 
         import json
 
         body = json.loads(route.calls[0].request.content)
-        assert body["resourceUUID"] == RESOURCE_UUID
+        assert "resourceUUID" not in body
         query = body["query"]
         assert query["expectedResultType"] == "COUNT"
         assert "authorizationFilters" not in query
@@ -743,11 +733,11 @@ class TestRunQueryLegacyPath:
         assert query["id"] is None
 
     @respx.mock
-    def test_session_with_legacy_flag_routes_to_legacy(self):
-        legacy = respx.post(LEGACY_QUERY_URL).mock(
+    def test_session_with_open_backend_routes_to_open(self):
+        open_route = respx.post(OPEN_QUERY_URL).mock(
             return_value=httpx.Response(200, content=b"3"),
         )
-        v3 = respx.post(QUERY_URL).mock(
+        auth = respx.post(QUERY_URL).mock(
             return_value=httpx.Response(401, text="Unauthorized"),
         )
         client = _make_client()
@@ -759,22 +749,22 @@ class TestRunQueryLegacyPath:
                 Resource(uuid=RESOURCE_UUID, name="R", description="d"),
             ],
             resource_uuid=RESOURCE_UUID,
-            use_legacy_query_path=True,
+            backend="open",
         )
 
         result = session.runQuery(_simple_clause(), type=QueryType.COUNT)
 
         assert isinstance(result, CountResult)
         assert result.value == 3
-        assert legacy.call_count == 1
-        assert v3.call_count == 0
+        assert open_route.call_count == 1
+        assert auth.call_count == 0
 
     @respx.mock
-    def test_session_without_legacy_flag_routes_to_v3(self):
-        v3 = respx.post(QUERY_URL).mock(
+    def test_session_default_backend_routes_to_auth(self):
+        auth = respx.post(QUERY_URL).mock(
             return_value=httpx.Response(200, content=b"5"),
         )
-        legacy = respx.post(LEGACY_QUERY_URL).mock(
+        open_route = respx.post(OPEN_QUERY_URL).mock(
             return_value=httpx.Response(401, text="Unauthorized"),
         )
         client = _make_client()
@@ -792,8 +782,8 @@ class TestRunQueryLegacyPath:
 
         assert isinstance(result, CountResult)
         assert result.value == 5
-        assert v3.call_count == 1
-        assert legacy.call_count == 0
+        assert auth.call_count == 1
+        assert open_route.call_count == 0
 
 
 class TestBuildQueryBodyGenomic:
@@ -803,7 +793,7 @@ class TestBuildQueryBodyGenomic:
 
         gf = buildGenomicFilter("Gene_with_variant", values=["BRCA1"])
         q = buildQuery(genomicFilters=gf, includeConcepts=["\\bmi\\"])
-        body = build_query_body(q, "uuid-1", "COUNT")
+        body = build_query_body(q, "COUNT")
         assert body["query"]["genomicFilters"] == [
             {"key": "Gene_with_variant", "values": ["BRCA1"]}
         ]
@@ -813,7 +803,7 @@ class TestBuildQueryBodyGenomic:
         from picsure._services.query_run import build_query_body
 
         c = buildClause("\\path\\", type=PhenotypicFilterType.FILTER, categories="X")
-        body = build_query_body(c, "uuid-1", "COUNT")
+        body = build_query_body(c, "COUNT")
         assert body["query"]["genomicFilters"] == []
 
     def test_genomic_filters_do_not_affect_select(self):
@@ -822,7 +812,7 @@ class TestBuildQueryBodyGenomic:
 
         gf = buildGenomicFilter("Gene_with_variant", values=["BRCA1"])
         q = buildQuery(genomicFilters=gf, includeConcepts=["\\bmi\\"])
-        body = build_query_body(q, "uuid-1", "DATAFRAME")
+        body = build_query_body(q, "DATAFRAME")
         assert body["query"]["select"] == ["\\bmi\\"]
 
 
@@ -943,7 +933,7 @@ class TestVariantResultParsing:
             return_value=httpx.Response(500, text="ri_error 500")
         )
         with pytest.raises(PicSureQueryError, match="not available on this"):
-            run_query(_make_client(), RESOURCE_UUID, _simple_clause(), "variant_count")
+            run_query(_make_client(), _simple_clause(), "variant_count", backend="auth")
 
     @respx.mock
     def test_nonvariant_500_stays_temporarily_unavailable(self):
@@ -951,4 +941,4 @@ class TestVariantResultParsing:
         # outage, not an unsupported feature.
         respx.post(QUERY_URL).mock(return_value=httpx.Response(500, text="boom"))
         with pytest.raises(PicSureConnectionError, match="temporarily unavailable"):
-            run_query(_make_client(), RESOURCE_UUID, _simple_clause(), "count")
+            run_query(_make_client(), _simple_clause(), "count", backend="auth")

--- a/tests/unit/test_query_save.py
+++ b/tests/unit/test_query_save.py
@@ -18,10 +18,9 @@ from picsure.errors import (
 
 BASE_URL = "https://api.example.com"
 TOKEN = "test-token"
-RESOURCE_UUID = "res-uuid-1111"
 
 LIST_URL = f"{BASE_URL}/picsure/dataset/named"
-SUBMIT_URL = f"{BASE_URL}/picsure/v3/query"
+SUBMIT_URL = f"{BASE_URL}/hpds/auth/v3/query"
 SAVE_URL = f"{BASE_URL}/picsure/dataset/named"
 
 
@@ -56,10 +55,9 @@ class TestSaveQueryByNameHappyPath:
 
         qid = save_query_by_name(
             _client(),
-            RESOURCE_UUID,
             _clause(),
             "fun",
-            use_legacy_query_path=False,
+            backend="auth",
         )
 
         assert qid == "qid-123"
@@ -87,10 +85,9 @@ class TestSaveQueryByNameHappyPath:
 
         qid = save_query_by_name(
             _client(),
-            RESOURCE_UUID,
             _clause(),
             "fun",
-            use_legacy_query_path=False,
+            backend="auth",
         )
         assert qid == "qid-9"
         assert save.called
@@ -105,10 +102,9 @@ class TestSaveQueryByNameHappyPath:
 
         qid = save_query_by_name(
             _client(),
-            RESOURCE_UUID,
             _clause(),
             "fun",
-            use_legacy_query_path=False,
+            backend="auth",
         )
         assert qid == "qid-fallback"
 
@@ -137,10 +133,9 @@ class TestSaveQueryByNameDuplicates:
         with pytest.raises(PicSureValidationError, match="already exists"):
             save_query_by_name(
                 _client(),
-                RESOURCE_UUID,
                 _clause(),
                 "fun",
-                use_legacy_query_path=False,
+                backend="auth",
             )
 
         assert not submit.called
@@ -182,10 +177,9 @@ class TestSaveQueryByNameDuplicates:
 
         qid = save_query_by_name(
             _client(),
-            RESOURCE_UUID,
             _clause(),
             "fun",
-            use_legacy_query_path=False,
+            backend="auth",
             overwrite=True,
         )
 
@@ -225,10 +219,9 @@ class TestSaveQueryByNameDuplicates:
         with pytest.raises(PicSureQueryError, match="missing its identifier"):
             save_query_by_name(
                 _client(),
-                RESOURCE_UUID,
                 _clause(),
                 "fun",
-                use_legacy_query_path=False,
+                backend="auth",
                 overwrite=True,
             )
 
@@ -243,10 +236,9 @@ class TestSaveQueryByNameDuplicates:
 
         qid = save_query_by_name(
             _client(),
-            RESOURCE_UUID,
             _clause(),
             "fun",
-            use_legacy_query_path=False,
+            backend="auth",
             overwrite=True,
         )
         assert qid == "qid-new"
@@ -254,15 +246,14 @@ class TestSaveQueryByNameDuplicates:
 
 
 class TestSaveQueryByNameOpenAccess:
-    def test_refuses_when_use_legacy_query_path_true(self):
+    def test_refuses_when_open_backend(self):
         # No network — the guard fires before any HTTP call.
         with pytest.raises(PicSureValidationError, match="open-access"):
             save_query_by_name(
                 _client(),
-                RESOURCE_UUID,
                 _clause(),
                 "fun",
-                use_legacy_query_path=True,
+                backend="open",
             )
 
 
@@ -280,10 +271,9 @@ class TestSaveQueryByNameNameValidation:
         with pytest.raises(PicSureValidationError, match="unsupported characters"):
             save_query_by_name(
                 _client(),
-                RESOURCE_UUID,
                 _clause(),
                 bad_name,
-                use_legacy_query_path=False,
+                backend="auth",
             )
 
     @pytest.mark.parametrize(
@@ -297,20 +287,18 @@ class TestSaveQueryByNameNameValidation:
         with pytest.raises(PicSureValidationError, match="unsupported characters"):
             save_query_by_name(
                 _client(),
-                RESOURCE_UUID,
                 _clause(),
                 bad_name,
-                use_legacy_query_path=False,
+                backend="auth",
             )
 
     def test_rejects_empty_name(self):
         with pytest.raises(PicSureValidationError, match="non-empty"):
             save_query_by_name(
                 _client(),
-                RESOURCE_UUID,
                 _clause(),
                 "",
-                use_legacy_query_path=False,
+                backend="auth",
             )
 
     def test_rejects_overlong_name(self):
@@ -318,10 +306,9 @@ class TestSaveQueryByNameNameValidation:
         with pytest.raises(PicSureValidationError, match="255"):
             save_query_by_name(
                 _client(),
-                RESOURCE_UUID,
                 _clause(),
                 too_long,
-                use_legacy_query_path=False,
+                backend="auth",
             )
 
     @pytest.mark.parametrize(
@@ -344,10 +331,9 @@ class TestSaveQueryByNameNameValidation:
 
         qid = save_query_by_name(
             _client(),
-            RESOURCE_UUID,
             _clause(),
             good_name,
-            use_legacy_query_path=False,
+            backend="auth",
         )
         assert qid == "qid-z"
 
@@ -360,10 +346,9 @@ class TestSaveQueryByNameTransportErrors:
         with pytest.raises(PicSureAuthError):
             save_query_by_name(
                 _client(),
-                RESOURCE_UUID,
                 _clause(),
                 "fun",
-                use_legacy_query_path=False,
+                backend="auth",
             )
 
     @respx.mock
@@ -374,10 +359,9 @@ class TestSaveQueryByNameTransportErrors:
         with pytest.raises(PicSureValidationError, match="submit"):
             save_query_by_name(
                 _client(),
-                RESOURCE_UUID,
                 _clause(),
                 "fun",
-                use_legacy_query_path=False,
+                backend="auth",
             )
 
     @respx.mock
@@ -391,10 +375,9 @@ class TestSaveQueryByNameTransportErrors:
         with pytest.raises(PicSureConnectionError):
             save_query_by_name(
                 _client(),
-                RESOURCE_UUID,
                 _clause(),
                 "fun",
-                use_legacy_query_path=False,
+                backend="auth",
             )
 
     @respx.mock
@@ -407,8 +390,7 @@ class TestSaveQueryByNameTransportErrors:
         with pytest.raises(PicSureQueryError, match="picsureResultId"):
             save_query_by_name(
                 _client(),
-                RESOURCE_UUID,
                 _clause(),
                 "fun",
-                use_legacy_query_path=False,
+                backend="auth",
             )

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -194,53 +194,6 @@ class TestSession:
             session.setResourceIDByName("nonexistent")
 
 
-class TestSessionDefaultResourceUuid:
-    def test_returns_explicit_resource_uuid_when_set(self):
-        client = MagicMock()
-        resources = [
-            Resource(uuid="uuid-1", name="A", description=""),
-            Resource(uuid="uuid-2", name="B", description=""),
-        ]
-        session = Session(
-            client=client,
-            user_email="u@e.com",
-            token_expiration="",
-            resources=resources,
-            resource_uuid="uuid-2",
-        )
-        assert session._default_resource_uuid() == "uuid-2"
-
-    def test_returns_single_resource_when_not_set(self):
-        session = _make_session(
-            resources=[Resource(uuid="only-uuid", name="Solo", description="")]
-        )
-        assert session._default_resource_uuid() == "only-uuid"
-
-    def test_raises_when_multiple_resources_unselected(self):
-        import pytest
-
-        from picsure.errors import PicSureValidationError
-
-        session = _make_session()
-        with pytest.raises(PicSureValidationError) as exc_info:
-            session._default_resource_uuid()
-        msg = str(exc_info.value)
-        assert "setResourceID" in msg
-        assert "Available resources:" in msg
-        assert "uuid-1" in msg
-        assert "Resource A" in msg
-        assert "uuid-2" in msg
-        assert "Resource B" in msg
-
-    def test_raises_when_no_resources(self):
-        session = _make_session(resources=[])
-        with __import__("pytest").raises(
-            __import__("picsure.errors", fromlist=["PicSureError"]).PicSureError,
-            match="No resources",
-        ):
-            session._default_resource_uuid()
-
-
 BASE_URL = "https://test.example.com"
 TOKEN = "test-token"
 
@@ -269,7 +222,7 @@ def _session_with_resources(
     *,
     resources: list[Resource],
     resource_uuid: str | None = None,
-    use_legacy_query_path: bool = False,
+    backend: str = "auth",
 ) -> Session:
     return Session(
         client=client,
@@ -277,7 +230,7 @@ def _session_with_resources(
         token_expiration="2030-01-01",
         resources=resources,
         resource_uuid=resource_uuid,
-        use_legacy_query_path=use_legacy_query_path,
+        backend=backend,
     )
 
 
@@ -480,7 +433,7 @@ class TestSessionShowAllFacets:
 class TestSessionRunQuery:
     @respx.mock
     def test_run_query_count(self):
-        respx.post(f"{BASE_URL}/picsure/v3/query/sync").mock(
+        respx.post(f"{BASE_URL}/hpds/auth/v3/query/sync").mock(
             return_value=httpx.Response(200, content=b"42")
         )
         from picsure._models.clause import Clause, PhenotypicFilterType
@@ -498,7 +451,7 @@ class TestSessionRunQuery:
 
     @respx.mock
     def test_run_query_participant(self, participant_response):
-        respx.post(f"{BASE_URL}/picsure/v3/query/sync").mock(
+        respx.post(f"{BASE_URL}/hpds/auth/v3/query/sync").mock(
             return_value=httpx.Response(200, content=participant_response)
         )
         from picsure._models.clause import Clause, PhenotypicFilterType
@@ -519,13 +472,13 @@ class TestSessionExport:
         # Session.exportAsPFB drives the async flow:
         # submit -> poll status -> stream result.
         query_id = "session-pfb-1"
-        respx.post(f"{BASE_URL}/picsure/v3/query").mock(
+        respx.post(f"{BASE_URL}/hpds/auth/v3/query").mock(
             return_value=httpx.Response(200, json={"picsureResultId": query_id})
         )
-        respx.post(f"{BASE_URL}/picsure/v3/query/{query_id}/status").mock(
+        respx.post(f"{BASE_URL}/hpds/auth/v3/query/{query_id}/status").mock(
             return_value=httpx.Response(200, json={"status": "AVAILABLE"})
         )
-        respx.post(f"{BASE_URL}/picsure/v3/query/{query_id}/result").mock(
+        respx.post(f"{BASE_URL}/hpds/auth/v3/query/{query_id}/result").mock(
             return_value=httpx.Response(200, content=b"pfb_data")
         )
         from unittest.mock import patch
@@ -558,7 +511,7 @@ class TestSessionExport:
             token_expiration="N/A",
             resources=[Resource(uuid="uuid-1", name="open-hpds", description="")],
             resource_uuid="uuid-1",
-            use_legacy_query_path=True,
+            backend="open",
         )
         clause = Clause(
             keys=["\\sex\\"], type=PhenotypicFilterType.FILTER, categories=["Male"]
@@ -576,13 +529,12 @@ class TestSessionExport:
 
     def test_save_query_by_name_forwards_to_service(self, monkeypatch):
         # Verify Session.saveQueryByName forwards to the service layer with
-        # the session-bound client, resource UUID, and legacy-flag.
+        # the session-bound client and backend.
         from picsure._models import session as session_module
 
         session = _make_session(
             resources=[Resource(uuid="uuid-1", name="hpds", description="x")],
         )
-        session._resource_uuid = "uuid-1"
         clause = Clause(
             keys=["\\sex\\"], type=PhenotypicFilterType.FILTER, categories=["Male"]
         )
@@ -591,18 +543,16 @@ class TestSessionExport:
 
         def fake_save(
             client,
-            resource_uuid,
             query,
             name,
             *,
-            use_legacy_query_path,
+            backend,
             overwrite,
         ):
             captured["client"] = client
-            captured["resource_uuid"] = resource_uuid
             captured["query"] = query
             captured["name"] = name
-            captured["use_legacy_query_path"] = use_legacy_query_path
+            captured["backend"] = backend
             captured["overwrite"] = overwrite
             return "qid-fake-001"
 
@@ -616,10 +566,9 @@ class TestSessionExport:
 
         assert qid == "qid-fake-001"
         assert captured["client"] is session._client
-        assert captured["resource_uuid"] == "uuid-1"
         assert captured["query"] is clause
         assert captured["name"] == "Cohort A"
-        assert captured["use_legacy_query_path"] is False
+        assert captured["backend"] == "auth"
         assert captured["overwrite"] is True
         # Silence unused-import warning from ruff for the imported alias.
         assert session_module.Session is Session
@@ -675,10 +624,10 @@ class TestSessionClose:
 
 class TestSessionLoadQueryByID:
     @respx.mock
-    def test_always_hits_legacy_metadata_endpoint(self):
-        # The v3 metadata endpoint is broken on BDC; loadQueryByID pins
-        # reads to the legacy path regardless of how the session was
-        # connected (authorized v3 sessions still hit legacy here).
+    def test_hits_non_versioned_metadata_endpoint(self):
+        # Query metadata is version-agnostic in the query-service, so
+        # loadQueryByID reads the non-versioned /hpds/{backend}/query/{id}/
+        # metadata route, never the /v3 one.
         client = _client()
         session = _session_with_resources(
             client,
@@ -694,10 +643,10 @@ class TestSessionLoadQueryByID:
                 "not": False,
             },
         )
-        legacy = respx.get(f"{BASE_URL}/picsure/query/abc-123/metadata").mock(
+        legacy = respx.get(f"{BASE_URL}/hpds/auth/query/abc-123/metadata").mock(
             return_value=httpx.Response(200, json=body)
         )
-        v3 = respx.get(f"{BASE_URL}/picsure/v3/query/abc-123/metadata").mock(
+        v3 = respx.get(f"{BASE_URL}/hpds/auth/v3/query/abc-123/metadata").mock(
             return_value=httpx.Response(200, json=body)
         )
         result = session.loadQueryByID("abc-123")
@@ -721,7 +670,7 @@ class TestSessionLoadQueryByID:
                 "not": False,
             },
         )
-        respx.get(f"{BASE_URL}/picsure/query/abc-123/metadata").mock(
+        respx.get(f"{BASE_URL}/hpds/auth/query/abc-123/metadata").mock(
             return_value=httpx.Response(200, json=body)
         )
         result = session.loadQueryByID("abc-123")
@@ -750,10 +699,10 @@ class TestSessionRunQueryByID:
                 "not": False,
             },
         )
-        metadata = respx.get(f"{BASE_URL}/picsure/query/abc-123/metadata").mock(
+        metadata = respx.get(f"{BASE_URL}/hpds/auth/query/abc-123/metadata").mock(
             return_value=httpx.Response(200, json=body)
         )
-        sync = respx.post(f"{BASE_URL}/picsure/v3/query/sync").mock(
+        sync = respx.post(f"{BASE_URL}/hpds/auth/v3/query/sync").mock(
             return_value=httpx.Response(200, content=b"42")
         )
 
@@ -781,10 +730,10 @@ class TestSessionRunQueryByID:
                 "not": False,
             },
         )
-        respx.get(f"{BASE_URL}/picsure/query/abc-123/metadata").mock(
+        respx.get(f"{BASE_URL}/hpds/auth/query/abc-123/metadata").mock(
             return_value=httpx.Response(200, json=body)
         )
-        respx.post(f"{BASE_URL}/picsure/v3/query/sync").mock(
+        respx.post(f"{BASE_URL}/hpds/auth/v3/query/sync").mock(
             return_value=httpx.Response(200, content=participant_response)
         )
 


### PR DESCRIPTION
**Step 2 (client migration) of the PIC-SURE gateway strangler-fig rewrite.** Moves the adapter off the legacy resource-UUID URL scheme onto the new gateway's path-based HPDS routes. Behaviorally identical from the caller's perspective — the public Python API surface is unchanged; only the internal URLs change.

### What moved (the three coupled changes, per gateway design spec §3.3/§3.4/§7)

1. **HPDS backend selection moves from a body `resourceUUID` to the URL path.** The gateway routes `/hpds/auth/**` (authorized/non-obfuscated) vs `/hpds/open/**` (open/aggregate); the backend is chosen by path, derived from the platform, not by which UUID is posted. New internal helper `_services/_hpds_paths.py` owns the route shape.

   | operation | old | new |
   |---|---|---|
   | `runQuery` | `/picsure/v3/query/sync` · `/picsure/query/sync` | `/hpds/auth/v3/query/sync` · `/hpds/open/query/sync` |
   | `exportAsPFB` | `/picsure/v3/query[/{id}/status\|result]` | `/hpds/auth/v3/query[/{id}/status\|result]` |
   | `saveQueryByName` (submit) | `/picsure/v3/query` | `/hpds/auth/v3/query` |
   | `loadQueryByID` (metadata) | `/picsure/query/{id}/metadata` | `/hpds/{backend}/query/{id}/metadata` |
   | `searchGenomicValues` | `/picsure/search/{uuid}/values/` | `/hpds/{backend}/search/{placeholder}/values/` |

   The auth backend keeps the v3 query lifecycle; the open backend keeps v1 — preserving today's split where the gateway serves open-access traffic only on v1.

2. **Resource registry removed.** `connect()` no longer calls `/info/resources`, and `setResourceID` no longer validates against a discovered registry. A plain authorized `connect()` now performs zero HTTP round-trips.

3. **Hardcoded open/auth resource UUIDs removed** from the `Platform` enum. The resource-**selection** UUID is dropped from query bodies (the gateway selects by path; the query-service only echoes it). The search route keeps a `{resourceId}` segment for ingress-contract parity, but it's a fixed, ignored placeholder — no semantically-meaningful body UUIDs (query/result ids) were touched.

### Compatibility
`resource_uuid` (connect kwarg) and `setResourceID` / `getResourceID` / `setResourceIDByName` are **retained** as a no-op-safe surface so existing caller code keeps working; they no longer drive routing or hit a registry.

### Explicitly out of scope (still served by the gateway's legacy catch-all → WildFly)
The dictionary-api proxy (`/picsure/proxy/dictionary-api/…`), named-dataset (`/picsure/dataset/named`), and PSAMA (`/psama/…`) paths are non-HPDS ingress and unchanged — they belong to separate migration steps.

### Tests
Full unit suite green (608 passed, 21 integration skipped); `ruff check` + `ruff format --check` + `mypy src/` all clean. Recorded fixtures/URL assertions updated to the new routes; registry-fetch and resource-UUID-body tests updated to the new behavior.

Draft — leaving open pending review and the coordinated gateway rollout.