### PR TITLE
feat: GenomicFilterKey enum + virtual Variant_severity mapping for buildGenomicFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,24 @@ filter by gene, consequence, and variant frequency, and discover valid values
 for any genomic key:
 
 ```python
-from picsure import buildGenomicFilter, buildQuery, VariantFrequency
+import picsure
 
-gene_filter = buildGenomicFilter("Gene_with_variant", values="BRCA2")
-freq_filter = buildGenomicFilter("Variant_frequency_as_text", values=VariantFrequency.RARE)
+gene_filter = picsure.buildGenomicFilter(
+    key=picsure.GenomicFilterKey.GENE_WITH_VARIANT, values="BRCA2"
+)
+freq_filter = picsure.buildGenomicFilter(
+    key=picsure.GenomicFilterKey.VARIANT_FREQUENCY_AS_TEXT,
+    values=picsure.VariantFrequency.RARE,
+)
+
+# Variant severity is a virtual key -> expands to Variant_consequence_calculated
+severe_filter = picsure.buildGenomicFilter(
+    key=picsure.GenomicFilterKey.VARIANT_SEVERITY,
+    values=picsure.VariantSeverity.HIGH,
+)
 
 # Genomic-only query
-genomic_query = buildQuery(genomicFilters=[gene_filter, freq_filter])
+genomic_query = picsure.buildQuery(genomicFilters=[gene_filter, freq_filter])
 count_result = session.runQuery(genomic_query, type="count")
 
 # Discover valid values for a genomic key

--- a/docs/guides/building-queries.md
+++ b/docs/guides/building-queries.md
@@ -180,24 +180,65 @@ the phenotypic filter when the query runs.
 
 ### Building a genomic filter
 
+Pass the annotation key as a `GenomicFilterKey` member (preferred) or the
+equivalent string — an unrecognized string raises an error listing the valid
+keys.
+
 ```python
-from picsure import buildGenomicFilter, VariantFrequency
+import picsure
 
 # Filter to a specific gene
-gene_filter = buildGenomicFilter("Gene_with_variant", values="BRCA2")
+gene_filter = picsure.buildGenomicFilter(
+    key=picsure.GenomicFilterKey.GENE_WITH_VARIANT, values="BRCA2"
+)
 
 # Multiple genes at once
-multi_gene = buildGenomicFilter("Gene_with_variant", values=["BRCA1", "BRCA2"])
+multi_gene = picsure.buildGenomicFilter(
+    key=picsure.GenomicFilterKey.GENE_WITH_VARIANT, values=["BRCA1", "BRCA2"]
+)
 
 # Filter by variant consequence
-csq_filter = buildGenomicFilter("Variant_consequence_calculated", values="missense_variant")
+csq_filter = picsure.buildGenomicFilter(
+    key=picsure.GenomicFilterKey.VARIANT_CONSEQUENCE_CALCULATED,
+    values="missense_variant",
+)
 
-# Filter by frequency using the VariantFrequency enum
-freq_filter = buildGenomicFilter("Variant_frequency_as_text", values=VariantFrequency.RARE)
+# Filter by frequency bucket using the VariantFrequency enum
+freq_filter = picsure.buildGenomicFilter(
+    key=picsure.GenomicFilterKey.VARIANT_FREQUENCY_AS_TEXT,
+    values=picsure.VariantFrequency.RARE,
+)
 ```
 
-`values` is required. Variant-spec and SNP keys are rejected with an actionable error.
-`VariantFrequency` has three members: `RARE`, `COMMON`, and `NOVEL`.
+`values` is required. Keys are validated against `GenomicFilterKey`; an
+unrecognized string key — or a variant-spec / SNP key (an rsID or
+`chr,pos,ref,alt`) — is rejected with an actionable error. `VariantFrequency`
+has three members: `RARE`, `COMMON`, and `NOVEL`.
+
+### Filtering by variant severity
+
+`Variant_severity` is a **virtual** key: the backend has no severity filter, so
+`buildGenomicFilter` expands a `VariantSeverity` bucket into the matching
+`Variant_consequence_calculated` values. Filter as if severity were a real key:
+
+```python
+import picsure
+
+# High-severity variants -> a Variant_consequence_calculated filter
+severe = picsure.buildGenomicFilter(
+    key=picsure.GenomicFilterKey.VARIANT_SEVERITY,
+    values=picsure.VariantSeverity.HIGH,
+)
+# severe.key == "Variant_consequence_calculated"
+
+# Multiple severities are unioned
+severe_or_moderate = picsure.buildGenomicFilter(
+    key=picsure.GenomicFilterKey.VARIANT_SEVERITY,
+    values=[picsure.VariantSeverity.HIGH, picsure.VariantSeverity.MEDIUM],
+)
+```
+
+`VariantSeverity` has three members: `HIGH`, `MEDIUM`, and `LOW`.
 
 ### Genomic-only query
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -93,6 +93,18 @@ Complete reference for all public functions, classes, and types in the
     options:
       members: true
 
+### GenomicFilterKey
+
+::: picsure.GenomicFilterKey
+    options:
+      members: true
+
+### VariantSeverity
+
+::: picsure.VariantSeverity
+    options:
+      members: true
+
 ## Session
 
 ::: picsure.Session

--- a/notebooks/10_Genomic_Filtering.ipynb
+++ b/notebooks/10_Genomic_Filtering.ipynb
@@ -168,6 +168,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cabb85e9",
+   "source": "## Filter keys — `GenomicFilterKey`\n\n`buildGenomicFilter(key, values=...)` accepts the annotation key as a\n`GenomicFilterKey` member (preferred) or the equivalent string. Strings are\nvalidated: an unrecognized key raises an error that lists the valid keys, so\ntypos fail fast instead of silently returning nothing.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "dd8bf49a",
+   "source": "# Enum key (preferred) — same picsure.<Enum>.<MEMBER> shape as PhenotypicFilterType\ngene_filter = picsure.buildGenomicFilter(\n    key=picsure.GenomicFilterKey.GENE_WITH_VARIANT, values=[GENE]\n)\ngene_filter.to_query_json()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "a1d330fe",
+   "source": "# An unrecognized string key fails fast with the list of valid keys.\ntry:\n    picsure.buildGenomicFilter(key=\"Variant_severty\", values=[\"x\"])  # typo\nexcept picsure.PicSureValidationError as err:\n    print(err)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "genomic-11",
    "metadata": {},
    "source": [
@@ -202,6 +224,20 @@
     ")\n",
     "rare_bucket.to_query_json()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf7452fd",
+   "source": "## Virtual key — `Variant_severity` → consequences\n\nThe backend has no `Variant_severity` filter, but severity is a natural way to\nthink about impact. `buildGenomicFilter` accepts\n`GenomicFilterKey.VARIANT_SEVERITY` and expands each `VariantSeverity` bucket\n(`HIGH`, `MEDIUM`, `LOW`) into the matching `Variant_consequence_calculated`\nvalues — the emitted filter uses the consequence key on the wire.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "0cdd5de3",
+   "source": "severe = picsure.buildGenomicFilter(\n    key=picsure.GenomicFilterKey.VARIANT_SEVERITY,\n    values=picsure.VariantSeverity.HIGH,\n)\nsevere.to_query_json()  # -> {\"key\": \"Variant_consequence_calculated\", \"values\": [...]}",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -337,7 +373,7 @@
    "cell_type": "markdown",
    "id": "genomic-33",
    "metadata": {},
-   "source": "## Recap / cheat sheet\n\n- **Discover values:** `session.searchGenomicValues(key, query=...)` (authorized; genes, consequences, any genomic key) and `picsure.genomicConsequences()` (offline consequence vocabulary by severity).\n- **Build one filter:** `picsure.buildGenomicFilter(key, values=...)` — one value or a list; matches any of them.\n- **Attach to a query:** `buildQuery(genomicFilters=one_or_a_list)`; combine with `phenotypicFilter=` to AND the two axes. Genomic-only queries are fine.\n- **Run it** (`count`, `participant`): the genomic filter is a constraint on *who* matches.\n- **Enum:** `VariantFrequency` (Rare/Common/Novel) — pass members straight to `values=`.\n- **Gotchas:** keys/genes are deployment-specific — discover them with `searchGenomicValues()` or the PIC-SURE UI. Variant-spec (SNP) filtering is not supported yet."
+   "source": "## Recap / cheat sheet\n\n- **Discover values:** `session.searchGenomicValues(key, query=...)` (authorized; genes, consequences, any genomic key) and `picsure.genomicConsequences()` (offline consequence vocabulary by severity).\n- **Build one filter:** `picsure.buildGenomicFilter(key, values=...)` — one value or a list; matches any of them.\n- **Attach to a query:** `buildQuery(genomicFilters=one_or_a_list)`; combine with `phenotypicFilter=` to AND the two axes. Genomic-only queries are fine.\n- **Run it** (`count`, `participant`): the genomic filter is a constraint on *who* matches.\n- **Enums:** `GenomicFilterKey` (annotation keys; pass to `key=`), `VariantFrequency` (Rare/Common/Novel), and `VariantSeverity` (High/Medium/Low → consequence expansion via the virtual `Variant_severity` key).\n- **Gotchas:** keys/genes are deployment-specific — discover them with `searchGenomicValues()` or the PIC-SURE UI. Variant-spec (SNP) filtering is not supported yet."
   }
  ],
  "metadata": {

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -21,7 +21,7 @@ know that step, but together they're the recommended on-ramp:
 | `7_Export_Query_As_PFB.ipynb`               | `exportAsPFB()` — write a cohort to disk as Avro/PFB.                   |
 | `8_Remove_and_Replace_Query_Functions.ipynb`| `replaceClause()` / `removeSubQuery()` — edit a query in place.         |
 | `9_Save_Query_By_Name.ipynb`                | `saveQueryByName()` — persist a query under a name on an auth platform. |
-| `10_Genomic_Filtering.ipynb`                | `buildGenomicFilter()` - filter by gene, consequence, and frequency; variant result types. |
+| `10_Genomic_Filtering.ipynb`                | `buildGenomicFilter()` — filter by gene, consequence, frequency, and severity using `GenomicFilterKey` / `VariantSeverity`; variant result types. |
 
 All eleven notebooks read your PIC-SURE access token from `notebooks/token.txt`
 (one line, no trailing newline required). The file is gitignored by

--- a/src/picsure/__init__.py
+++ b/src/picsure/__init__.py
@@ -6,7 +6,12 @@ from picsure._models.clause import Clause, PhenotypicFilterType
 from picsure._models.clause_group import ClauseGroup, GroupOperator
 from picsure._models.count_result import CountResult
 from picsure._models.facet import FacetSet
-from picsure._models.genomic_filter import GenomicFilter, VariantFrequency
+from picsure._models.genomic_filter import (
+    GenomicFilter,
+    GenomicFilterKey,
+    VariantFrequency,
+    VariantSeverity,
+)
 from picsure._models.query import Query
 from picsure._models.query_type import QueryType
 from picsure._models.session import Session
@@ -56,6 +61,7 @@ __all__ = [
     "CountResult",
     "FacetSet",
     "GenomicFilter",
+    "GenomicFilterKey",
     "GroupOperator",
     "PhenotypicFilterType",
     "PicSureAuthError",
@@ -68,4 +74,5 @@ __all__ = [
     "QueryType",
     "Session",
     "VariantFrequency",
+    "VariantSeverity",
 ]

--- a/src/picsure/_models/genomic_filter.py
+++ b/src/picsure/_models/genomic_filter.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from enum import Enum
+from functools import lru_cache
+from importlib import resources
 
 
 class VariantFrequency(str, Enum):
@@ -20,6 +23,66 @@ class VariantFrequency(str, Enum):
     RARE = "Rare"
     COMMON = "Common"
     NOVEL = "Novel"
+
+
+class GenomicFilterKey(str, Enum):
+    """Recognized genomic annotation keys for ``buildGenomicFilter(key=...)``.
+
+    Pass a member directly, or the equivalent string (validated against these
+    members). ``VARIANT_SEVERITY`` is a *virtual* key: the backend has no
+    ``Variant_severity`` filter, so the builder expands it to the matching
+    ``Variant_consequence_calculated`` values (see :class:`VariantSeverity`).
+    """
+
+    GENE_WITH_VARIANT = "Gene_with_variant"
+    VARIANT_CONSEQUENCE_CALCULATED = "Variant_consequence_calculated"
+    VARIANT_FREQUENCY_AS_TEXT = "Variant_frequency_as_text"
+    VARIANT_CLASS = "Variant_class"
+    VARIANT_SEVERITY = "Variant_severity"
+
+
+class VariantSeverity(str, Enum):
+    """Severity buckets for the virtual ``Variant_severity`` key.
+
+    Each member maps to a set of ``Variant_consequence_calculated`` values;
+    ``buildGenomicFilter`` expands it so filtering by severity behaves as if
+    the backend supported a ``Variant_severity`` key.
+    """
+
+    HIGH = "High Severity"
+    MEDIUM = "Medium Severity"
+    LOW = "Low Severity"
+
+
+@lru_cache(maxsize=1)
+def _severity_map() -> dict[str, tuple[str, ...]]:
+    """Load ``variant_consequences.json`` as ``{severity_label: consequences}``.
+
+    Pure JSON (no pandas), cached once. Same bundled file
+    ``genomicConsequences()`` reads, keyed by severity label
+    (``"High Severity"`` ...).
+    """
+    raw = (
+        resources.files("picsure._data")
+        .joinpath("variant_consequences.json")
+        .read_text(encoding="utf-8")
+    )
+    groups = json.loads(raw)
+    return {group["key"]: tuple(group["children"]) for group in groups}
+
+
+def known_severities() -> tuple[str, ...]:
+    """Return the valid severity labels, in file order (for error messages)."""
+    return tuple(_severity_map().keys())
+
+
+def severity_consequences(severity: str) -> tuple[str, ...]:
+    """Return the consequences for one severity label.
+
+    Raises:
+        KeyError: If ``severity`` is not a known severity label.
+    """
+    return _severity_map()[severity]
 
 
 # Variant-spec (SNP) keys are recognized server-side by

--- a/src/picsure/_services/query_build.py
+++ b/src/picsure/_services/query_build.py
@@ -5,7 +5,13 @@ from enum import Enum
 
 from picsure._models.clause import Clause, PhenotypicFilterType
 from picsure._models.clause_group import ClauseGroup, GroupOperator
-from picsure._models.genomic_filter import GenomicFilter, is_variant_spec
+from picsure._models.genomic_filter import (
+    GenomicFilter,
+    GenomicFilterKey,
+    is_variant_spec,
+    known_severities,
+    severity_consequences,
+)
 from picsure._models.query import Query
 from picsure.errors import PicSureValidationError
 
@@ -213,47 +219,67 @@ def buildQuery(  # noqa: N802
 
 
 def buildGenomicFilter(  # noqa: N802
-    key: str,
+    key: str | GenomicFilterKey,
     *,
     values: str | Sequence[str],
 ) -> GenomicFilter:
     """Create a single categorical genomic (variant-annotation) filter.
 
     Args:
-        key: The genomic annotation to filter on. Known keys include
-            ``"Gene_with_variant"``, ``"Variant_consequence_calculated"``, and
-            ``"Variant_frequency_as_text"`` (use :class:`VariantFrequency`).
-            The exact set is platform-dependent and validated server-side.
-            Variant-spec (SNP) keys — an rsID or a ``chr,pos,ref,alt`` spec —
-            are not supported yet and are rejected.
+        key: The genomic annotation to filter on. Pass a
+            :class:`GenomicFilterKey` member (preferred) or the equivalent
+            string — an unrecognized string raises an error listing the valid
+            keys. ``GenomicFilterKey.VARIANT_SEVERITY`` is a *virtual* key: the
+            backend has no ``Variant_severity`` filter, so this builder expands
+            the requested :class:`VariantSeverity` buckets into the matching
+            ``Variant_consequence_calculated`` values. Variant-spec (SNP) keys —
+            an rsID or a ``chr,pos,ref,alt`` spec — are not supported and are
+            rejected.
         values: One value or a sequence of values that must match.
-            :class:`VariantFrequency` members are accepted and coerced to their
-            string value.
+            :class:`VariantFrequency` / :class:`VariantSeverity` members are
+            accepted and coerced to their string value.
 
     Returns:
         A :class:`GenomicFilter` to pass to ``buildQuery(genomicFilters=...)``.
+        For ``VARIANT_SEVERITY`` the returned filter's ``key`` is
+        ``"Variant_consequence_calculated"``.
 
     Raises:
-        PicSureValidationError: If ``key`` is empty, ``key`` is a variant-spec
-            (SNP) key, or ``values`` is empty or contains blank strings.
+        PicSureValidationError: If ``key`` is empty, unrecognized, or a
+            variant-spec (SNP) key; if ``values`` is empty or contains blank
+            strings; or if a ``VARIANT_SEVERITY`` value is not a valid severity.
 
     Example:
-        >>> from picsure import buildGenomicFilter, VariantFrequency
-        >>> gene = buildGenomicFilter("Gene_with_variant", values=["BRCA1"])
-        >>> rare = buildGenomicFilter(
-        ...     "Variant_frequency_as_text", values=VariantFrequency.RARE
+        >>> from picsure import buildGenomicFilter, GenomicFilterKey, VariantSeverity
+        >>> gene = buildGenomicFilter(
+        ...     GenomicFilterKey.GENE_WITH_VARIANT, values=["BRCA1"]
+        ... )
+        >>> severe = buildGenomicFilter(
+        ...     GenomicFilterKey.VARIANT_SEVERITY, values=VariantSeverity.HIGH
         ... )
     """
-    if not isinstance(key, str) or not key.strip():
+    if isinstance(key, GenomicFilterKey):
+        resolved = key
+    elif isinstance(key, str) and key.strip():
+        try:
+            resolved = GenomicFilterKey(key)
+        except ValueError:
+            if is_variant_spec(key):
+                raise PicSureValidationError(
+                    "Variant-spec (SNP) genomic filtering is not supported yet; "
+                    f"the key {key!r} looks like a specific variant. Filter by a "
+                    "gene or annotation key (e.g. 'Gene_with_variant') instead."
+                ) from None
+            valid_keys = ", ".join(k.value for k in GenomicFilterKey)
+            raise PicSureValidationError(
+                f"{key!r} is not a recognized genomic filter key. Valid keys: "
+                f"{valid_keys}. Pass a GenomicFilterKey member or one of these "
+                "strings."
+            ) from None
+    else:
         raise PicSureValidationError(
-            "buildGenomicFilter requires a non-empty 'key' string."
-        )
-
-    if is_variant_spec(key):
-        raise PicSureValidationError(
-            f"Variant-spec (SNP) genomic filtering is not supported yet; the "
-            f"key {key!r} looks like a specific variant. Filter by a gene or "
-            "annotation key (e.g. 'Gene_with_variant') instead."
+            "buildGenomicFilter requires a non-empty 'key' string or a "
+            "GenomicFilterKey member."
         )
 
     items = [values] if isinstance(values, str) else list(values)
@@ -267,4 +293,22 @@ def buildGenomicFilter(  # noqa: N802
             "buildGenomicFilter 'values' must not contain empty or blank strings."
         )
 
-    return GenomicFilter(key=key, values=normalized)
+    if resolved is GenomicFilterKey.VARIANT_SEVERITY:
+        expanded: list[str] = []
+        for severity in normalized:
+            try:
+                expanded.extend(severity_consequences(severity))
+            except KeyError:
+                valid_severities = ", ".join(known_severities())
+                raise PicSureValidationError(
+                    f"{severity!r} is not a valid variant severity. Valid "
+                    f"severities: {valid_severities}. Pass a VariantSeverity "
+                    "member or one of these strings."
+                ) from None
+        effective_key = GenomicFilterKey.VARIANT_CONSEQUENCE_CALCULATED.value
+        effective_values = tuple(dict.fromkeys(expanded))
+    else:
+        effective_key = resolved.value
+        effective_values = normalized
+
+    return GenomicFilter(key=effective_key, values=effective_values)

--- a/tests/unit/test_genomic_filter.py
+++ b/tests/unit/test_genomic_filter.py
@@ -49,3 +49,61 @@ def test_is_variant_spec_matches_specs_not_annotation_keys():
     assert not is_variant_spec("Gene_with_variant")
     assert not is_variant_spec("Variant_consequence_calculated")
     assert not is_variant_spec("Variant_frequency_as_text")
+
+
+def test_genomic_filter_key_values():
+    from picsure._models.genomic_filter import GenomicFilterKey
+
+    assert GenomicFilterKey.GENE_WITH_VARIANT == "Gene_with_variant"
+    key = GenomicFilterKey.VARIANT_CONSEQUENCE_CALCULATED
+    assert key == "Variant_consequence_calculated"
+    assert GenomicFilterKey.VARIANT_FREQUENCY_AS_TEXT == "Variant_frequency_as_text"
+    assert GenomicFilterKey.VARIANT_CLASS == "Variant_class"
+    assert GenomicFilterKey.VARIANT_SEVERITY == "Variant_severity"
+
+
+def test_variant_severity_values():
+    from picsure._models.genomic_filter import VariantSeverity
+
+    assert VariantSeverity.HIGH == "High Severity"
+    assert VariantSeverity.MEDIUM == "Medium Severity"
+    assert VariantSeverity.LOW == "Low Severity"
+
+
+def test_known_severities_order():
+    from picsure._models.genomic_filter import known_severities
+
+    assert known_severities() == ("High Severity", "Medium Severity", "Low Severity")
+
+
+def test_severity_consequences_high_exact():
+    from picsure._models.genomic_filter import severity_consequences
+
+    assert severity_consequences("High Severity") == (
+        "splice_acceptor_variant",
+        "splice_donor_variant",
+        "stop_gained",
+        "frameshift_variant",
+        "stop_lost",
+        "start_lost",
+    )
+    assert "missense_variant" in severity_consequences("Medium Severity")
+    assert "synonymous_variant" in severity_consequences("Low Severity")
+
+
+def test_severity_consequences_unknown_raises_keyerror():
+    import pytest
+
+    from picsure._models.genomic_filter import severity_consequences
+
+    with pytest.raises(KeyError):
+        severity_consequences("HIGH")
+
+
+def test_key_and_severity_enums_re_exported():
+    import picsure
+
+    assert picsure.GenomicFilterKey.GENE_WITH_VARIANT == "Gene_with_variant"
+    assert picsure.VariantSeverity.HIGH == "High Severity"
+    assert "GenomicFilterKey" in picsure.__all__
+    assert "VariantSeverity" in picsure.__all__

--- a/tests/unit/test_query_build.py
+++ b/tests/unit/test_query_build.py
@@ -363,3 +363,81 @@ class TestBuildQueryGenomic:
     def test_empty_still_rejected(self):
         with pytest.raises(PicSureValidationError):
             buildQuery()
+
+
+class TestGenomicFilterKeyEnum:
+    def test_accepts_enum_key(self):
+        from picsure import GenomicFilterKey, buildGenomicFilter
+
+        gf = buildGenomicFilter(GenomicFilterKey.GENE_WITH_VARIANT, values=["BRCA1"])
+        assert gf.key == "Gene_with_variant"
+        assert gf.values == ("BRCA1",)
+
+    def test_accepts_valid_string_key(self):
+        from picsure import buildGenomicFilter
+
+        gf = buildGenomicFilter("Variant_class", values=["SNV"])
+        assert gf.key == "Variant_class"
+
+    def test_unknown_string_key_is_rejected(self):
+        from picsure import PicSureValidationError, buildGenomicFilter
+
+        with pytest.raises(
+            PicSureValidationError, match="not a recognized genomic filter key"
+        ):
+            buildGenomicFilter("Variant_severty", values=["x"])
+
+    def test_unknown_key_error_lists_valid_keys(self):
+        from picsure import PicSureValidationError, buildGenomicFilter
+
+        with pytest.raises(PicSureValidationError, match="Gene_with_variant"):
+            buildGenomicFilter("nope", values=["x"])
+
+    def test_snp_key_still_reports_snp(self):
+        from picsure import PicSureValidationError, buildGenomicFilter
+
+        with pytest.raises(PicSureValidationError, match="SNP"):
+            buildGenomicFilter("rs123", values=["x"])
+
+    def test_severity_enum_expands_to_consequences(self):
+        from picsure import GenomicFilterKey, VariantSeverity, buildGenomicFilter
+
+        gf = buildGenomicFilter(
+            GenomicFilterKey.VARIANT_SEVERITY, values=VariantSeverity.HIGH
+        )
+        assert gf.key == "Variant_consequence_calculated"
+        assert gf.values == (
+            "splice_acceptor_variant",
+            "splice_donor_variant",
+            "stop_gained",
+            "frameshift_variant",
+            "stop_lost",
+            "start_lost",
+        )
+
+    def test_severity_string_label_expands(self):
+        from picsure import buildGenomicFilter
+
+        gf = buildGenomicFilter("Variant_severity", values="High Severity")
+        assert gf.key == "Variant_consequence_calculated"
+        assert "stop_gained" in gf.values
+
+    def test_multiple_severities_union_dedup_ordered(self):
+        from picsure import GenomicFilterKey, VariantSeverity, buildGenomicFilter
+
+        gf = buildGenomicFilter(
+            GenomicFilterKey.VARIANT_SEVERITY,
+            values=[VariantSeverity.HIGH, VariantSeverity.MEDIUM],
+        )
+        assert gf.key == "Variant_consequence_calculated"
+        assert gf.values[0] == "splice_acceptor_variant"
+        assert "missense_variant" in gf.values
+        assert len(gf.values) == len(set(gf.values))
+
+    def test_unknown_severity_value_is_rejected(self):
+        from picsure import GenomicFilterKey, PicSureValidationError, buildGenomicFilter
+
+        with pytest.raises(
+            PicSureValidationError, match="not a valid variant severity"
+        ):
+            buildGenomicFilter(GenomicFilterKey.VARIANT_SEVERITY, values="HIGH")


### PR DESCRIPTION
## Summary

Adds a typed genomic-filter-key API to `buildGenomicFilter`.

- New `GenomicFilterKey` and `VariantSeverity` enums (`str`-mixin, re-exported from `picsure`).
- `buildGenomicFilter(key=...)` now accepts a `GenomicFilterKey` member **or** a validated string. An unrecognized string raises `PicSureValidationError` listing the valid keys; the existing variant-spec / SNP-key message is preserved.
- **Virtual `Variant_severity` key:** the backend has no severity filter, so the builder expands the requested `VariantSeverity` buckets (`HIGH`/`MEDIUM`/`LOW`) into a single `Variant_consequence_calculated` filter — order-preserved and de-duped — using the already-bundled `variant_consequences.json`.
- Docs updated: API reference, the building-queries guide, README, and notebook `10_Genomic_Filtering.ipynb`.

## Behavior

- Key and severity matching are exact (case-sensitive): `VariantSeverity.HIGH` / `"High Severity"` are accepted; `"HIGH"` is not.
- Backward compatible: valid string keys, the empty-key ("non-empty") and blank-value errors, and SNP/rsID rejection are all preserved.

## Example

```python
import picsure

picsure.buildGenomicFilter(key=picsure.GenomicFilterKey.GENE_WITH_VARIANT, values=["BRCA1"])
picsure.buildGenomicFilter(key=picsure.GenomicFilterKey.VARIANT_SEVERITY, values=picsure.VariantSeverity.HIGH)
# -> GenomicFilter(key="Variant_consequence_calculated", values=(... high-severity consequences ...))
```

## Testing

- `uv run pytest`: 653 passed, 21 skipped.
- `uv run ruff check src/ tests/`, `ruff format --check`, `uv run mypy src/`: all clean.

Companion R change (kwargs forwarded 1:1): hms-dbmi/pic-sure-r-adapter-hpds#27.
