### PR TITLE
[ALS-12481] Read consents from /user/me/consents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- `connect()` now sources the user's consent list from PSAMA's `/psama/user/me/consents` instead of `/psama/user/me/queryTemplate/`. The consent endpoint returns the identifiers directly, so the adapter no longer parses a doubly-encoded query template. The resulting `Session.consents` value is unchanged. Requires a backend that serves `/user/me/consents`.
+
 ## [2.0.0] - 2026-06-15
 
 ### Changed

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -108,7 +108,7 @@ src/picsure/
 | `query_load.py`  | `load_query(client, query_id)`. Hits the saved-query endpoint and reconstructs a `Clause` / `ClauseGroup` from the response so it can be re-run via `runQueryByID`. |
 | `query_save.py`  | `save_query_by_name(client, resource_uuid, query, name, *, use_legacy_query_path, overwrite)`. Submits the query via `POST /picsure/v3/query`, then `POST`s a new record to `/dataset/named/` (or `PUT`-updates an existing one when `overwrite=True`). Validates `name` against the backend `NamedDataset` pattern client-side. Refused on open-access deployments. |
 | `export.py`      | `export_pfb` — the async PFB flow (submit → poll with exponential backoff capped at 60s, 10-minute total deadline → stream result to a `.part` file → atomic rename). Plus `export_csv` and `export_tsv` for in-memory DataFrames. |
-| `consents.py`    | `fetch_consents(client)`. Reads `/psama/user/me/queryTemplate/`, parses the doubly-encoded JSON, and pulls the `\\_consents\\` study-consent list used by dictionary-api requests on authorized deployments. |
+| `consents.py`    | `fetch_consents(client)`. Reads `/psama/user/me/consents` and pulls the `\\_consents\\` study-consent list used by dictionary-api requests on authorized deployments. |
 
 ### `_transport/` — HTTP
 

--- a/src/picsure/_services/consents.py
+++ b/src/picsure/_services/consents.py
@@ -1,58 +1,48 @@
 from __future__ import annotations
 
-import json
-
 from picsure._transport.client import PicSureClient
 from picsure._transport.errors import TransportError
 from picsure.errors import PicSureConnectionError
 
-_QUERY_TEMPLATE_PATH = "/psama/user/me/queryTemplate/"
+_CONSENTS_PATH = "/psama/user/me/consents"
 _CONSENTS_KEY = "\\_consents\\"
 
 
 def fetch_consents(client: PicSureClient) -> list[str]:
-    """Fetch the user's consent list from the PSAMA query template.
+    """Fetch the user's consent list from PSAMA.
 
-    The query template endpoint returns a JSON object whose
-    ``queryTemplate`` field is itself a JSON-encoded string.  Inside
-    that string, ``categoryFilters["\\\\_consents\\\\"]`` holds the
-    list of study-consent identifiers the user is authorized for.
-    That list is what dictionary-api calls require on authorized
-    deployments.
+    The consents endpoint returns the user's ``UserConsents`` record,
+    whose ``consents`` field maps category keys to identifier lists.
+    ``consents["\\\\_consents\\\\"]`` holds the study-consent identifiers
+    the user is authorized for, which is what dictionary-api calls
+    require on authorized deployments.
+
+    A user with no consent record yields an empty ``consents`` map, so
+    an empty list here means "no authorized studies", not a failure.
 
     Args:
         client: Authenticated HTTP client.
 
     Returns:
         The list of consent identifiers (e.g. ``["phs000007.c1", ...]``).
-        Empty list if the template, filters, or consents key is missing.
+        Empty list if the record or the consents key is missing.
 
     Raises:
-        PicSureConnectionError: If the HTTP call fails or the template
-            is not valid JSON.
+        PicSureConnectionError: If the HTTP call fails.
     """
     try:
-        response = client.get_json(_QUERY_TEMPLATE_PATH)
+        response = client.get_json(_CONSENTS_PATH)
     except TransportError as exc:
         raise PicSureConnectionError(
             "Could not fetch your consent list from PSAMA. "
             "The server may be temporarily unavailable."
         ) from exc
 
-    template_raw = response.get("queryTemplate")
-    if not isinstance(template_raw, str):
+    consents_map = response.get("consents")
+    if not isinstance(consents_map, dict):
         return []
 
-    try:
-        template = json.loads(template_raw)
-    except json.JSONDecodeError as exc:
-        raise PicSureConnectionError(
-            "Received a malformed query template from PSAMA. "
-            "Contact your PIC-SURE administrator if this persists."
-        ) from exc
-
-    filters = template.get("categoryFilters", {})
-    consents = filters.get(_CONSENTS_KEY, [])
+    consents = consents_map.get(_CONSENTS_KEY, [])
     if not isinstance(consents, list):
         return []
     return [str(c) for c in consents]

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -189,29 +189,29 @@ class TestConnectValidation:
 
 
 class TestConnectConsents:
-    _TEMPLATE_URL = f"{BASE_URL}/psama/user/me/queryTemplate/"
+    _CONSENTS_URL = f"{BASE_URL}/psama/user/me/consents"
     _CONSENT_PAYLOAD = {
-        "queryTemplate": (
-            '{"categoryFilters":{"\\\\_consents\\\\":["phs000007.c1","phs001013.c1"]}}'
-        )
+        "uuid": "8f14e45f-ceea-467a-a3cd-9f1ee0e5f0a1",
+        "userId": "3c59dc04-8e88-450b-a0f2-3a1e1f1b1c2d",
+        "consents": {"\\_consents\\": ["phs000007.c1", "phs001013.c1"]},
     }
 
     @respx.mock
     def test_custom_url_skips_consent_fetch_by_default(self, resources_response):
         _mock_connect_flow(resources_response)
-        template_route = respx.get(self._TEMPLATE_URL).mock(
+        consents_route = respx.get(self._CONSENTS_URL).mock(
             return_value=httpx.Response(200, json=self._CONSENT_PAYLOAD)
         )
 
         session = connect(platform=BASE_URL, token=TOKEN)
 
-        assert template_route.called is False
+        assert consents_route.called is False
         assert session.consents == []
 
     @respx.mock
     def test_include_consents_kwarg_fetches_consents(self, resources_response):
         _mock_connect_flow(resources_response)
-        respx.get(self._TEMPLATE_URL).mock(
+        respx.get(self._CONSENTS_URL).mock(
             return_value=httpx.Response(200, json=self._CONSENT_PAYLOAD)
         )
 
@@ -225,7 +225,7 @@ class TestConnectConsents:
 
         prod_url = Platform.BDC_AUTHORIZED.url
         _mock_connect_flow(resources_response, host=prod_url)
-        template_route = respx.get(f"{prod_url}/psama/user/me/queryTemplate/").mock(
+        consents_route = respx.get(f"{prod_url}/psama/user/me/consents").mock(
             return_value=httpx.Response(200, json=self._CONSENT_PAYLOAD)
         )
 
@@ -233,7 +233,7 @@ class TestConnectConsents:
             platform=Platform.BDC_AUTHORIZED, token=TOKEN, include_consents=False
         )
 
-        assert template_route.called is False
+        assert consents_route.called is False
         assert session.consents == []
 
 
@@ -261,13 +261,13 @@ class TestConnectOpenAccess:
         respx.get(f"{host}/picsure/info/resources").mock(
             return_value=httpx.Response(200, json=resources_response)
         )
-        template_route = respx.get(f"{host}/psama/user/me/queryTemplate/").mock(
+        consents_route = respx.get(f"{host}/psama/user/me/consents").mock(
             return_value=httpx.Response(200, json={})
         )
 
         connect(platform=Platform.BDC_DEV_OPEN)
 
-        assert template_route.called is False
+        assert consents_route.called is False
 
     @respx.mock
     def test_open_platform_resources_401_degrades_to_empty(self):
@@ -344,7 +344,7 @@ class TestConnectLegacyQueryPath:
 
         host = Platform.BDC_DEV_AUTHORIZED.url
         _mock_connect_flow(resources_response, host=host)
-        respx.get(f"{host}/psama/user/me/queryTemplate/").mock(
+        respx.get(f"{host}/psama/user/me/consents").mock(
             return_value=httpx.Response(200, json={})
         )
 
@@ -379,7 +379,7 @@ class TestConnectLegacyQueryPath:
         # If the deployment requires consents (even with auth on), it's
         # an authorized backend — stay on v3.
         _mock_connect_flow(resources_response)
-        respx.get(f"{BASE_URL}/psama/user/me/queryTemplate/").mock(
+        respx.get(f"{BASE_URL}/psama/user/me/consents").mock(
             return_value=httpx.Response(200, json={})
         )
 

--- a/tests/unit/test_consents.py
+++ b/tests/unit/test_consents.py
@@ -1,5 +1,3 @@
-import json
-
 import httpx
 import pytest
 import respx
@@ -10,84 +8,93 @@ from picsure.errors import PicSureConnectionError
 
 BASE_URL = "https://test.example.com"
 TOKEN = "test-token"
-TEMPLATE_URL = f"{BASE_URL}/psama/user/me/queryTemplate/"
+CONSENTS_URL = f"{BASE_URL}/psama/user/me/consents"
 
 
 def _make_client() -> PicSureClient:
     return PicSureClient(base_url=BASE_URL, token=TOKEN)
 
 
-def _wrap_template(inner: dict) -> dict:
-    return {"queryTemplate": json.dumps(inner)}
+def _wrap_consents(consents: object) -> dict:
+    """Shape the PSAMA UserConsents entity around a consents map."""
+    return {
+        "uuid": "8f14e45f-ceea-467a-a3cd-9f1ee0e5f0a1",
+        "userId": "3c59dc04-8e88-450b-a0f2-3a1e1f1b1c2d",
+        "consents": consents,
+    }
 
 
 class TestFetchConsents:
     @respx.mock
     def test_returns_consents_list(self):
-        inner = {
-            "categoryFilters": {
-                "\\_consents\\": ["phs000007.c1", "phs000179.c1", "phs001013.c1"],
-            },
-        }
-        respx.get(TEMPLATE_URL).mock(
-            return_value=httpx.Response(200, json=_wrap_template(inner))
+        respx.get(CONSENTS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=_wrap_consents(
+                    {"\\_consents\\": ["phs000007.c1", "phs000179.c1", "phs001013.c1"]}
+                ),
+            )
         )
         consents = fetch_consents(_make_client())
         assert consents == ["phs000007.c1", "phs000179.c1", "phs001013.c1"]
 
     @respx.mock
     def test_ignores_harmonized_and_topmed_keys(self):
-        inner = {
-            "categoryFilters": {
-                "\\_harmonized_consent\\": ["other.c1"],
-                "\\_consents\\": ["phs000007.c1"],
-                "\\_topmed_consents\\": ["tm.c1"],
-            },
-        }
-        respx.get(TEMPLATE_URL).mock(
-            return_value=httpx.Response(200, json=_wrap_template(inner))
+        respx.get(CONSENTS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=_wrap_consents(
+                    {
+                        "\\_harmonized_consent\\": ["other.c1"],
+                        "\\_consents\\": ["phs000007.c1"],
+                        "\\_topmed_consents\\": ["tm.c1"],
+                    }
+                ),
+            )
         )
         assert fetch_consents(_make_client()) == ["phs000007.c1"]
 
     @respx.mock
-    def test_missing_query_template_returns_empty(self):
-        respx.get(TEMPLATE_URL).mock(return_value=httpx.Response(200, json={}))
+    def test_missing_consents_object_returns_empty(self):
+        respx.get(CONSENTS_URL).mock(return_value=httpx.Response(200, json={}))
         assert fetch_consents(_make_client()) == []
 
     @respx.mock
-    def test_missing_category_filters_returns_empty(self):
-        respx.get(TEMPLATE_URL).mock(
-            return_value=httpx.Response(200, json=_wrap_template({}))
+    def test_null_consents_returns_empty(self):
+        """A user with no consent row gets a null consents map, not an error."""
+        respx.get(CONSENTS_URL).mock(
+            return_value=httpx.Response(200, json=_wrap_consents(None))
+        )
+        assert fetch_consents(_make_client()) == []
+
+    @respx.mock
+    def test_empty_consents_object_returns_empty(self):
+        respx.get(CONSENTS_URL).mock(
+            return_value=httpx.Response(200, json=_wrap_consents({}))
         )
         assert fetch_consents(_make_client()) == []
 
     @respx.mock
     def test_missing_consents_key_returns_empty(self):
-        inner = {"categoryFilters": {"\\_harmonized_consent\\": ["other.c1"]}}
-        respx.get(TEMPLATE_URL).mock(
-            return_value=httpx.Response(200, json=_wrap_template(inner))
+        respx.get(CONSENTS_URL).mock(
+            return_value=httpx.Response(
+                200, json=_wrap_consents({"\\_harmonized_consent\\": ["other.c1"]})
+            )
         )
         assert fetch_consents(_make_client()) == []
 
     @respx.mock
     def test_non_list_consents_returns_empty(self):
-        inner = {"categoryFilters": {"\\_consents\\": "not-a-list"}}
-        respx.get(TEMPLATE_URL).mock(
-            return_value=httpx.Response(200, json=_wrap_template(inner))
+        respx.get(CONSENTS_URL).mock(
+            return_value=httpx.Response(
+                200, json=_wrap_consents({"\\_consents\\": "not-a-list"})
+            )
         )
         assert fetch_consents(_make_client()) == []
 
     @respx.mock
-    def test_malformed_template_raises(self):
-        respx.get(TEMPLATE_URL).mock(
-            return_value=httpx.Response(200, json={"queryTemplate": "{not json"})
-        )
-        with pytest.raises(PicSureConnectionError, match="malformed"):
-            fetch_consents(_make_client())
-
-    @respx.mock
     def test_server_error_raises_connection_error(self):
-        respx.get(TEMPLATE_URL).mock(
+        respx.get(CONSENTS_URL).mock(
             return_value=httpx.Response(500, text="Internal Server Error")
         )
         with pytest.raises(PicSureConnectionError, match="consent"):
@@ -95,7 +102,7 @@ class TestFetchConsents:
 
     @respx.mock
     def test_network_error_raises_connection_error(self):
-        respx.get(TEMPLATE_URL).mock(
+        respx.get(CONSENTS_URL).mock(
             side_effect=httpx.ConnectError("Connection refused")
         )
         with pytest.raises(PicSureConnectionError):


### PR DESCRIPTION
fetch_consents sourced the user's consent list from PSAMA's query template, which returned a JSON object whose queryTemplate field was itself a JSON-encoded string holding categoryFilters["\_consents\"].

Read /psama/user/me/consents instead. It returns the UserConsents record directly, so the consent identifiers are one lookup away rather than behind a second decode, and the malformed-template error path disappears with it. The category keys are unchanged, as is the list fetch_consents returns and the Session.consents value built from it.

A user with no stored consent record yields an empty consents map, so connect() reports no authorized studies rather than failing.

Requires a backend serving /user/me/consents.